### PR TITLE
Fix: Make release drafter use variables for URL

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -65,4 +65,4 @@ template: |
   $CHANGES
 
   ## Links
-  - [Submit bugs/feature requests](https://github.com/lfreleng-actions/actions-template/issues)
+  - [Submit bugs/feature requests](https://github.com/$OWNER/$REPOSITORY/issues)


### PR DESCRIPTION
The release drafter was using a hardcoded URL for the bug tracker. This
change makes it use the variables that are available to it to make it
the template repository more portable.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
