### PR TITLE
Chore: Update linting, add schema validation, add job timeouts

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -30,6 +30,7 @@ jobs:
       # write permission is required for autolabeler
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0

--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -22,25 +22,26 @@ jobs:
     runs-on: 'ubuntu-24.04'
     permissions:
       contents: write
+    timeout-minutes: 3
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0  # v2.12.0
         with:
           egress-policy: audit
 
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 'Verify Pushed Tag'
-      # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/tag-push-verify-action@lfreleng-actions/tag-push-verify-action # v0.1.0
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/tag-push-verify-action@f9c6e753870c6405883be2ba18af05d075aaffe8  # v0.1.0
         with:
           versioning: 'semver'
 
       - name: 'Promote draft release'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/draft-release-promote-action@0392844e1e08a0539b63ba1940a7a2bfa2bda077 # v0.1.1
+        uses: lfreleng-actions/draft-release-promote-action@0392844e1e08a0539b63ba1940a7a2bfa2bda077  # v0.1.1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag: "${{ github.ref_name }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         types: [yaml]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: f0fe93c067104b76ffb58852abe79673a8429bd1  # frozen: v0.11.8
+    rev: 24e02b24b8ab2b7c76225602d13fa60e12d114e6  # frozen: v0.11.9
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$
@@ -92,3 +92,18 @@ repos:
     hooks:
       - id: codespell
         args: ["--ignore-words=.codespell"]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema.git
+    rev: 06e4cc849d03f3a59ca223a4046f4bb5bb2aba6d  # frozen: 0.33.0
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+      - id: check-jsonschema
+        name: Check GitHub Workflows set timeout-minutes
+        args:
+          - --builtin-schema
+          - github-workflows-require-timeout
+        files: ^\.github/workflows/[^/]+$
+        types:
+          - yaml
+      - id: check-readthedocs

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,6 @@ inputs:
   input:
     description: "Description of input"
     required: true
-    type: 'string'
 
 outputs:
   output:


### PR DESCRIPTION
Additional linting tools add action/workflow schema validation. The linting update also highlighted missing job timeout values. Also fixes incorrect call to tag-push-verify-action.