### PR TITLE
CI: Update pre-commit commit-message templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,14 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ci:
-  autofix_commit_msg: "Chore: pre-commit autoupdate"
-  autoupdate_commit_msg: "Chore: pre-commit autoupdate"
+  autofix_commit_msg: |
+    Chore: pre-commit autofixes
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
+  autoupdate_commit_msg: |
+    Chore: pre-commit autoupdate
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
 
 exclude: "^docs/conf.py"
 


### PR DESCRIPTION
Add in forced DCO line for pre-commit commit messages. This will ensure
that all commit messages generated by pre-commit include a DCO line,
which is a requirement to pass the gitlint check.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
