### PR TITLE
Chore: Update line-length rules in template files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,10 +14,10 @@ indent_size = 4
 indent_size = 2
 
 [*.markdown]
-max_line_length = 80
+max_line_length = 120
 
 [*.py]
-max_line_legth = 120
+max_line_length = 120
 
 [*.sh]
-max_line_length = 80
+max_line_length = 120

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,18 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# Markdownlint configuration
+# See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+default: true
+
+# MD013: Line length
+MD013:
+  line_length: 120
+  # Allow long lines in tables
+  tables: false
+  # Allow long lines in code blocks
+  code_blocks: false
+  # Allow long lines with headings
+  headings: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,15 @@ ci:
 
     Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
 
-exclude: "^docs/conf.py"
+exclude: |
+  (?x)^(docs/conf.py|
+        \.mypy_cache/|
+        \.pytest_cache/|
+        \.ruff_cache/|
+        dist/|
+        build/|
+        coverage_html_report/|
+        \.venv/)
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -62,6 +70,16 @@ repos:
     rev: 412de98d50e846f31ea6f4b0ad036f2c24a7a024  # frozen: v1.17.1
     hooks:
       - id: mypy
+        additional_dependencies:
+          - types-PyYAML
+          - types-requests
+
+  # Node.js downloads sometimes fail in pre-commit.ci
+  # - repo: https://github.com/RobertCraigie/pyright-python
+  #  rev: d393df1703a808473b84bd14a2702f4793014031  # frozen: v1.1.404
+  #  hooks:
+  #    - id: pyright
+  #      files: ^(src|scripts|tests|custom_components)/.+\.py$
 
   - repo: https://github.com/btford/write-good
     rev: ab66ce10136dfad5146e69e70f82a3efac8842c1 # frozen: v1.0.8
@@ -78,7 +96,7 @@ repos:
     rev: 192ad822316c3a22fb3d3cc8aa6eafa0b8488360  # frozen: v0.45.0
     hooks:
       - id: markdownlint
-        args: ["--fix"]
+        args: ["--fix", "--config", ".markdownlint.yaml"]
 
   - repo: https://github.com/fsfe/reuse-tool
     rev: 60dfc6b2ad9e1f3eabfbcf3a0dc202ee89dc5a00 # frozen: v5.0.2

--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,5 @@ rules:
     # prettier forces 1 space comment separator
     min-spaces-from-content: 1
     level: error
+  line-length:
+    max: 120


### PR DESCRIPTION
We are losing too much time to the existing line length limits in our linting setup. The AI coding tools struggle with this, and constantly wrapping lines to 80 characters is wasting precious time/effort. Also, it often introduces bugs/breakage that require additional rounds of fixes. I've lost hours to this now, and now believe strongly that the marginal benefits do not justify the existence of this rule.

I will happily go to war on this topic.

This pull request adjusts the limits to a more modern 120 characters.