### PR TITLE
Fix: harden tag-push workflow

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-# Runs on tag push, promotes draft release
+# Runs on tag push, validates and promotes draft release
 name: 'Release on Tag Push 🚀'
 
 # yamllint disable-line rule:truthy
@@ -14,16 +14,16 @@ on:
 permissions: {}
 
 jobs:
-  promote-release:
-    name: 'Promote Draft Release'
+  validate_tag:
+    name: 'Validate Tag'
+    # Skip tag deletion events
+    if: "!github.event.deleted"
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: read
     timeout-minutes: 5
     outputs:
-      # Allow downstream jobs to use the validated tag name
-      # Published for reference purposes, despite not being used here
-      tag: "${{ steps.tag-validate.outputs.tag_name }}"
+      tag: "${{ steps.tag_validate.outputs.tag_name }}"
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 'Verify pushed tag'
-        id: 'tag-validate'
+        id: tag_validate
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/tag-validate-action@67695fa3d045917ca7ecc0f1d5f0cad03e231104  # v1.0.1
         with:
@@ -46,10 +46,24 @@ jobs:
           # yamllint disable-line rule:line-length
           require_signed: 'ssh,gpg-unverifiable'  # Cannot verify GPG without key
 
+  promote_release:
+    name: 'Promote Draft Release'
+    needs: validate_tag
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: write
+    timeout-minutes: 5
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176  # v2.17.0
+        with:
+          egress-policy: audit
+
       - name: 'Promote draft release'
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/draft-release-promote-action@cd7cf442875ecaea5dbb070d0de94f21ece107c8  # v0.1.3
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ steps.tag-validate.outputs.tag_name }}"
+          tag: "${{ needs.validate_tag.outputs.tag }}"
           latest: true


### PR DESCRIPTION
Harden the `tag-push.yaml` workflow template with three improvements:

### Changes

1. **Split into two jobs for least-privilege permissions**
   - `validate_tag` job runs with `contents: read` — validates the tag
   - `promote_release` job runs with `contents: write` — promotes the draft release
   - Validation code no longer executes with write permissions

2. **Add tag deletion guard**
   - `if: "!github.event.deleted"` on the validate job
   - Prevents the workflow from running on tag deletion events
   - Still allows tag creation and tag repoint/force-move events

3. **Use underscores in job and step IDs**
   - `validate-tag` → `validate_tag`, `promote-release` → `promote_release`
   - `id: tag-validate` → `id: tag_validate`
   - Avoids ambiguity in GitHub Actions expressions where hyphens
     can be misinterpreted as subtraction operators

These fixes were identified during Copilot review of downstream rollout PRs.