### PR TITLE
Fix: add checkout to promote_release job

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -33,6 +33,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 'Verify pushed tag'
         id: tag_validate
@@ -56,9 +58,14 @@ jobs:
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176  # v2.17.0
+      - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
         with:
           egress-policy: audit
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 'Promote draft release'
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
Add the missing `actions/checkout` step to the `promote_release` job in `tag-push.yaml` and bump `harden-runner` to v2.18.0.

### Problem

The `draft-release-promote-action` internally runs `git` commands and requires a checked-out repository. When the workflow was split into two jobs (`validate_tag` and `promote_release`) in PR #151, the checkout step was only included in the validation job. This causes the promote step to fail with:

```
fatal: not a git repository (or any of the parent directories): .git
```

### Fix

- Add `actions/checkout@v6.0.2` to the `promote_release` job before the draft release promotion step
- Bump `harden-runner` from v2.17.0 to v2.18.0 in the `promote_release` job for consistency with `validate_tag`
- Set `persist-credentials: false` on both checkout steps to reduce token exposure, since downstream actions receive tokens via explicit `token` inputs (addresses Copilot feedback from lfreleng-actions/checkout-gerrit-change-action#84)