### PR TITLE
Fix: Harden clear-action-cache workflow step summary and permissions

### DIFF
--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -48,7 +48,6 @@ jobs:
     permissions:
       # Actions cache deletion requires the actions: write scope.
       actions: write
-      contents: read
     steps:
       # Harden the runner
       # yamllint disable-line rule:line-length
@@ -131,17 +130,37 @@ jobs:
             echo "|----------|-------|"
             echo "| Total entries | $before_count |"
             echo "| Matched | $matched_count |"
-            echo "| Key filter | \`${KEY_PATTERN:-<none>}\` |"
-            echo "| Ref filter | \`${REF_FILTER:-<none>}\` |"
             echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+            echo ""
+            # Render user-controlled filter inputs inside a fenced
+            # code block. KEY_PATTERN and REF_FILTER are free-form
+            # workflow_dispatch inputs and may contain characters
+            # (|, backticks, newlines) that would break table
+            # rendering or inject markup into the step summary.
+            # jq @json safely quotes/escapes the values.
+            echo "### Filters"
+            echo ""
+            echo '```text'
+            jq -nr \
+              --arg key "${KEY_PATTERN:-}" \
+              --arg ref "${REF_FILTER:-}" \
+              '"key_pattern=\($key|@json)\nref_filter=\($ref|@json)"'
+            echo '```'
             echo ""
             if [ "$matched_count" -gt 0 ]; then
               echo "### Matched entries"
               echo ""
-              echo "| ID | Size (bytes) | Ref | Key |"
-              echo "|----|--------------|-----|-----|"
-              printf '%s\n' "$filtered" | jq -r \
-                '"| \(.id) | \(.size_in_bytes) | \(.ref) | \(.key) |"'
+              # Emit as a fenced code block rather than a Markdown
+              # table: cache keys and refs are user-controlled and
+              # may contain characters (|, backticks, newlines) that
+              # would otherwise break table rendering or allow
+              # injection into the step summary.
+              echo '```text'
+              printf '%s\n' "$filtered" | jq -r '
+                  "id=\(.id)  size=\(.size_in_bytes)B  " +
+                  "ref=\(.ref|tojson)  key=\(.key|tojson)"
+                '
+              echo '```'
               echo ""
             fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Follow-up to #155 addressing Copilot review feedback and a manual permissions tightening on the new `clear-action-cache.yaml` workflow.

## Changes

### Fix: Avoid Markdown-table injection in the step summary

Copilot flagged that the "Matched entries" section of the step summary printed user-controlled cache `ref` and `key` values directly into a Markdown table:

> The step summary prints cache ref and key values into a Markdown table. Cache keys/refs are user-controlled and can contain `|`, backticks, or newlines, which will break the table rendering (and can make the summary misleading). Consider escaping/normalizing these values before writing the table, or emitting the matched entries in a fenced code block instead of a table.

This PR takes the second option: matched entries are now emitted inside a fenced ```` ```text ```` code block. Each line is rendered via `jq` as:

```
id=<id>  size=<bytes>B  ref=<ref|tojson>  key=<key|tojson>
```

Using `tojson` for `ref` and `key` quotes the strings and escapes embedded quotes/backslashes/newlines, so cache entries with unusual characters can no longer break the summary or inject markup.

### Chore: Remove unused `contents: read` job permission

The `clear-cache` job only interacts with the GitHub Actions cache REST API, which requires `actions: write`. It does not read repository contents (no checkout, no source access), so the `contents: read` permission has been removed to follow the principle of least privilege.

The job now declares only:

```
permissions:
  actions: write
```

## Notes

- Pre-commit hooks (yamllint, actionlint, workflow validators, etc.) all pass locally.
- No behavioural change to cache deletion logic itself.
