### PR TITLE
CI: Add OpenSSF wf, README badges, normalise workflow names

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -18,9 +18,6 @@ on:
     - cron: "50 4 * * 0"
   push:
     branches: ["main", "master"]
-    paths:
-      - "**"
-      - "!.github/**"
 
 # Declare default permissions as none.
 permissions: {}
@@ -30,12 +27,12 @@ jobs:
     name: "OpenSSF Scorecard"
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@2f4f1db634cdecc9af63d7946cb6b818ce590484  # v0.3.3
-    # v0.2.28
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
+      # Needed to read repository contents (checkout, etc.).
+      contents: read
+      # Needed to upload the results to the code-scanning dashboard.
       security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
+      # Needed to publish results and obtain a Scorecard badge via OIDC.
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
+      # Uncomment the permission below if installing in a private repository.
       # actions: read

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -1,0 +1,41 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: "OpenSSF Scorecard"
+on:
+  workflow_dispatch:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "50 4 * * 0"
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "**"
+      - "!.github/**"
+
+# Declare default permissions as none.
+permissions: {}
+
+jobs:
+  openssf-scorecard:
+    name: "OpenSSF Scorecard"
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@2f4f1db634cdecc9af63d7946cb6b818ce590484  # v0.3.3
+    # v0.2.28
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read

--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-name: '🛠️ Semantic Pull Request'
+name: 'Semantic Pull Request 🛠️'
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/sha-pinned-actions.yaml
+++ b/.github/workflows/sha-pinned-actions.yaml
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Verifies action/workflow calls are pinned to SHA commit values
-name: '📌 Audit GitHub Actions'
+name: 'Audit GitHub Actions 📌'
 
 # yamllint disable-line rule:truthy
 on:

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable-next-line MD013 -->
-[![Linux Foundation](https://img.shields.io/badge/Linux-Foundation-blue)](https://linuxfoundation.org/) [![Source Code](https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white&color=blue)](https://github.com/lfreleng-actions/actions-template) [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![pre-commit.ci status badge]][pre-commit.ci results page] [![🔐 CodeQL](https://github.com/lfreleng-actions/actions-template/actions/workflows/codeql.yml/badge.svg)](https://github.com/lfreleng-actions/actions-template/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lfreleng-actions/actions-template/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/actions-template)
+[![Linux Foundation](https://img.shields.io/badge/Linux-Foundation-blue)](https://linuxfoundation.org/) [![Source Code](https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white&color=blue)](https://github.com/lfreleng-actions/actions-template) [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![pre-commit.ci status badge]][pre-commit.ci results page] [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lfreleng-actions/actions-template/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/actions-template)
 <!-- prettier-ignore-end -->
 
-This is a template for the other actions in this Github organisation.
+This is a template for the other actions in this GitHub organisation.
 
 ## actions-template
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable-next-line MD013 -->
-[![Linux Foundation](https://img.shields.io/badge/Linux-Foundation-blue)](https://linuxfoundation.org/) [![Source Code](https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white&color=blue)](https://github.com/lfreleng-actions/actions-template) [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lfreleng-actions/actions-template/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/actions-template)
+[![Linux Foundation](https://img.shields.io/badge/Linux-Foundation-blue)](https://linuxfoundation.org/) [![Source Code](https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white&color=blue)](https://github.com/lfreleng-actions/actions-template) [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![pre-commit.ci status badge]][pre-commit.ci results page] [![🔐 CodeQL](https://github.com/lfreleng-actions/actions-template/actions/workflows/codeql.yml/badge.svg)](https://github.com/lfreleng-actions/actions-template/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lfreleng-actions/actions-template/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/actions-template)
 <!-- prettier-ignore-end -->
 
 This is a template for the other actions in this Github organisation.
@@ -52,3 +52,6 @@ steps:
 ## Implementation Details
 
 ## Notes
+
+[pre-commit.ci results page]: https://results.pre-commit.ci/latest/github/lfreleng-actions/actions-template/main
+[pre-commit.ci status badge]: https://results.pre-commit.ci/badge/github/lfreleng-actions/actions-template/main.svg

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 
 # 🛠️ Template Action
 
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable-next-line MD013 -->
+[![Linux Foundation](https://img.shields.io/badge/Linux-Foundation-blue)](https://linuxfoundation.org/) [![Source Code](https://img.shields.io/badge/GitHub-100000?logo=github&logoColor=white&color=blue)](https://github.com/lfreleng-actions/actions-template) [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lfreleng-actions/actions-template/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/actions-template)
+<!-- prettier-ignore-end -->
+
 This is a template for the other actions in this Github organisation.
 
 ## actions-template


### PR DESCRIPTION
## Summary

Updates to the template repo, intended to flow downstream to other actions:

1. **CI: Add OpenSSF Scorecard workflow** — adds `.github/workflows/openssf-scorecard.yaml` so new actions inherit Scorecard analysis.
2. **Docs: Add OpenSSF Scorecard badge to README** — uses the canonical single-slash form (the double-slash variant in some existing repos still resolves but is non-canonical; see lfreleng-actions/test-python-project#240).
3. **Docs: Expand README badges (pre-commit.ci)** — adds the remaining language-agnostic badges from the standard set used across `lfreleng-actions` repos (Linux Foundation, Source Code, License, pre-commit.ci, OpenSSF Scorecard). The CodeQL badge is intentionally **not** included in this template: CodeQL is enabled via the org-level "default" setup, which does not produce a `.github/workflows/codeql.yml` file to badge. Repos that opt into CodeQL "advanced" setup can add the badge locally. Language-specific badges (e.g. PyPI) are also intentionally omitted from the template.
4. **Style: Move leading emojis to end of workflow names** — standardises naming so emojis appear after the plain text description, matching the convention already used by the other workflows in this template (e.g. `Test GitHub Action 🧪`, `Clear Action Cache 🧹`, `Release on Tag Push 🚀`).
   - `'🛠️ Semantic Pull Request'` → `'Semantic Pull Request 🛠️'`
   - `'📌 Audit GitHub Actions'`   → `'Audit GitHub Actions 📌'`
5. **Docs: Address Copilot review feedback** — adds `contents: read` to the Scorecard job permissions, removes a stale version annotation, replaces an inaccurate comment, drops the (broken) CodeQL badge from the README, and corrects "Github" → "GitHub" in the description text.

## Verification

- `prek run --all-files` passes locally (all hooks).
- Each commit is DCO signed-off.
- Commits follow the repo's capitalised-type convention (`CI:`, `Docs:`, `Style:`).
