### PR TITLE
Chore(deps): Add cooldown and refine commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,10 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "Chore"
+      prefix: "CI(actions)"
+    # Wait before opening a bump PR so we don't churn on a release
+    # that gets retracted or superseded shortly after it ships.
+    # This is required to satisfy the zizmor workflow auditing tool.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 15


### PR DESCRIPTION
## Summary

Aligns the template's `dependabot.yml` with the configuration just
adopted in `lfreleng-actions/.github` (see PR #11 there):

- **Add a 7-day cooldown** on the `github-actions` ecosystem so
  Dependabot does not open a bump PR for a release that gets
  retracted or superseded shortly after it ships. This also
  satisfies zizmor's `dependabot-cooldown` audit, which the
  org-wide `🌈 Zizmor Scan` workflow (advisory mode) reports
  against every repository.
- **Refine the commit-message prefix** from the generic `Chore`
  to `CI(actions)`. The `CI` type identifies the layer (CI / GHA
  configuration); the `actions` scope identifies what is being
  bumped (action pins in `uses:` lines). This pairs nicely with
  `Chore(deps)` for runtime dependency updates in repositories
  that have them, so a `git log` skim immediately distinguishes
  CI infrastructure bumps from application dependency bumps.

## Why now

Every new repository templated from `actions-template` inherits
this file, so propagating the change here keeps newly-bootstrapped
repos consistent with the org-wide zizmor scan's expectations.
Existing repositories will pick the change up via the next
template-sync cycle.

## Diff

```yaml
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "Chore"
+      prefix: "CI(actions)"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 15
```

Co-authored-by: Claude &lt;claude@anthropic.com&gt;
