### PR TITLE
CI: Add zizmor GHA auditing tool/workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,17 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 15
+
+  # zizmor pin, consumed by .github/workflows/zizmor.yaml.
+  # The pin file is read by the workflow at run-time (with grep);
+  # pip never installs from it. This ecosystem entry exists solely so
+  # Dependabot keeps the pinned zizmor version current.
+  - package-ecosystem: "pip"
+    directory: "/.github/dependabot"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Chore(deps)"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15

--- a/.github/dependabot/zizmor-requirements.txt
+++ b/.github/dependabot/zizmor-requirements.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# Pin for the zizmor static analyser used by .github/workflows/zizmor.yaml.
+#
+# This file exists solely so Dependabot can keep the zizmor version
+# current via its pip ecosystem (see .github/dependabot.yml). The
+# workflow reads the pin from this file at run-time with grep; it is
+# never installed by pip itself.
+#
+# Edit format: a single line of `zizmor==<version>`. Do not add other
+# packages here.
+zizmor==1.24.1

--- a/.github/scripts/zizmor_summary.py
+++ b/.github/scripts/zizmor_summary.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Summarise a zizmor SARIF report for the GitHub Actions step summary.
+
+Default mode (no arguments): read the SARIF file at ``$ZIZMOR_SARIF``
+and write a human-readable markdown summary to ``$GITHUB_STEP_SUMMARY``.
+Also emit a compact listing to stdout and
+``::warning``/``::error``/``::notice`` workflow commands for the top
+findings so they surface as inline PR annotations.
+
+Helper mode (``--regen-workflow``): regenerate the base64-encoded copy
+of this script that lives in ``.github/workflows/zizmor.yaml`` under
+``env.ZIZMOR_SUMMARY_B64``. The workflow file embeds the parser as
+base64 because it is invoked as a required workflow against repos that
+do not contain this script. After editing this file, run::
+
+    python3 .github/scripts/zizmor_summary.py --regen-workflow
+
+then commit both files together.
+"""
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from posixpath import basename
+from urllib.parse import quote
+
+# Marker used by --regen-workflow to locate the embedded base64 block.
+_B64_MARKER = "ZIZMOR_SUMMARY_B64: |"
+_B64_INDENT = " " * 12
+
+LEVEL_LABEL = {
+    "error": "\u26d4 High",
+    "warning": "\u26a0\ufe0f Medium",
+    "note": "\U0001f4dd Low",
+    "none": "\u2139\ufe0f Info",
+}
+LEVEL_ORDER = ["error", "warning", "note", "none"]
+WARN_CMD = {
+    "error": "error", "warning": "warning",
+    "note": "notice", "none": "notice",
+}
+
+
+def strip_rule_prefix(rid: str) -> str:
+    """Drop the ``zizmor/`` prefix from a rule id for tighter tables."""
+    if rid.startswith("zizmor/"):
+        return rid[len("zizmor/"):]
+    return rid
+
+
+def _escape_wf_data(value: object) -> str:
+    """Escape the message body of a GitHub workflow command.
+
+    Per GitHub's workflow-command rules, ``%``, ``CR`` and ``LF`` must
+    be percent-encoded in the data (post-``::``) portion.
+    """
+    return (
+        str(value)
+        .replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+
+
+def _escape_wf_property(value: object) -> str:
+    """Escape a property value of a GitHub workflow command.
+
+    Properties live in the comma-separated ``key=value`` list before
+    ``::``. In addition to the data-escapes, ``,`` and ``:`` must be
+    encoded so they cannot terminate the property list or the command
+    prefix.
+    """
+    return (
+        _escape_wf_data(value)
+        .replace(":", "%3A")
+        .replace(",", "%2C")
+    )
+
+
+def _render_link(file: str, line, repo: str, sha: str, server: str) -> str:
+    """Render a path:line link with the basename as visible text."""
+    if not file:
+        return ""
+    short = basename(file) or file
+    label = short + (f":{line}" if line else "")
+    if not repo or not sha:
+        return f"`{label}`"
+    anchor = f"#L{line}" if line else ""
+    url = f"{server}/{repo}/blob/{sha}/{quote(file)}{anchor}"
+    return f"[`{label}`]({url})"
+
+
+def _load_findings(sarif_path: Path):
+    """Parse SARIF and return (findings, level_counts, rule_counts)."""
+    with sarif_path.open() as fh:
+        data = json.load(fh)
+
+    findings = []
+    rule_meta = {}
+    for run in data.get("runs", []):
+        tool = run.get("tool", {}).get("driver", {})
+        for rule in tool.get("rules", []):
+            rule_meta[rule.get("id", "")] = rule
+        for result in run.get("results", []):
+            rid = result.get("ruleId", "?")
+            level = (
+                result.get("level")
+                or rule_meta.get(rid, {})
+                    .get("defaultConfiguration", {})
+                    .get("level", "warning")
+            )
+            msg = (result.get("message") or {}).get("text", "").strip()
+            loc = (result.get("locations") or [{}])[0]
+            ploc = loc.get("physicalLocation", {})
+            artifact = ploc.get("artifactLocation", {}).get("uri", "")
+            region = ploc.get("region", {}) or {}
+            line = region.get("startLine")
+            endline = region.get("endLine") or line
+            findings.append({
+                "rule": rid,
+                "level": level,
+                "msg": msg,
+                "file": artifact,
+                "line": line,
+                "endline": endline,
+            })
+
+    def sort_key(f):
+        try:
+            idx = LEVEL_ORDER.index(f["level"])
+        except ValueError:
+            idx = 99
+        return (idx, f["rule"], f["file"], f["line"] or 0)
+
+    findings.sort(key=sort_key)
+    level_counts = Counter(f["level"] for f in findings)
+    rule_counts = Counter(f["rule"] for f in findings)
+    return findings, level_counts, rule_counts
+
+
+def summarise() -> int:
+    """Read SARIF and write summary; return process exit code."""
+    sarif_path = Path(os.environ["ZIZMOR_SARIF"])
+    top_n = int(os.environ.get("ZIZMOR_TOP_N", "10"))
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    sha = os.environ.get("GITHUB_SHA", "")
+    persona = os.environ.get("ZIZMOR_PERSONA", "regular")
+    min_severity = os.environ.get("ZIZMOR_MIN_SEVERITY", "medium")
+
+    findings, level_counts, rule_counts = _load_findings(sarif_path)
+    total = sum(level_counts.values())
+    short_sha = sha[:7] if sha else "?"
+
+    out = ["# \U0001f308 Zizmor Scan", ""]
+    if total == 0:
+        out.append(f"No findings at or above `{min_severity}` \u2705")
+    else:
+        out.append(
+            f"{total} finding(s) at or above `{min_severity}` \u26a0\ufe0f"
+        )
+    out.extend([
+        "",
+        f"`{repo}@{short_sha}`",
+        f"persona: `{persona}`",
+        f"min-severity: `{min_severity}`",
+        "",
+    ])
+
+    if total > 0:
+        out.append("## Counts by severity")
+        out.append("")
+        out.append("| Severity | Count |")
+        out.append("| --- | ---: |")
+        for lvl in LEVEL_ORDER:
+            if lvl in level_counts:
+                out.append(
+                    f"| {LEVEL_LABEL.get(lvl, lvl)} | {level_counts[lvl]} |"
+                )
+        out.append("")
+        out.append("## Counts by rule")
+        out.append("")
+        out.append("| Rule | Count |")
+        out.append("| --- | ---: |")
+        for rid, n in rule_counts.most_common():
+            out.append(f"| `{strip_rule_prefix(rid)}` | {n} |")
+        out.append("")
+        shown = findings[:top_n]
+        extra = total - len(shown)
+        heading = f"## Top {len(shown)} findings"
+        if extra > 0:
+            heading += f" (of {total}; {extra} more in SARIF)"
+        out.append(heading)
+        out.append("")
+        out.append("| Severity | Rule | Location | Message |")
+        out.append("| --- | --- | --- | --- |")
+        for f in shown:
+            label = LEVEL_LABEL.get(f["level"], f["level"])
+            msg = f["msg"].replace("|", "\\|").replace("\n", " ")
+            if len(msg) > 200:
+                msg = msg[:197] + "..."
+            rule_short = strip_rule_prefix(f["rule"])
+            loc = _render_link(f["file"], f["line"], repo, sha, server)
+            out.append(
+                f"| {label} | `{rule_short}` | {loc} | {msg} |"
+            )
+
+    summary = "\n".join(out) + "\n"
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(summary)
+
+    print("::group::zizmor summary")
+    by_level = {LEVEL_LABEL.get(k, k): v for k, v in level_counts.items()}
+    print(
+        f"Total: {total}  by-level: {by_level}  rules: {len(rule_counts)}"
+    )
+    for f in findings[:top_n]:
+        label = LEVEL_LABEL.get(f["level"], f["level"])
+        loc_str = f["file"] + (f":{f['line']}" if f["line"] else "")
+        rule_short = strip_rule_prefix(f["rule"])
+        print(f"  {label}  {rule_short:<28}  {loc_str}")
+    print("::endgroup::")
+
+    # Workflow commands keep the full rule id in the title since
+    # GitHub shows them out of context (e.g. in PR file annotations).
+    # Property values are escaped per GitHub's workflow-command rules
+    # so ``,`` and ``:`` in titles or paths cannot break the format.
+    for f in findings[:top_n]:
+        cmd = WARN_CMD.get(f["level"], "warning")
+        parts = []
+        if f["file"]:
+            parts.append(f"file={_escape_wf_property(f['file'])}")
+        if f["line"]:
+            parts.append(f"line={f['line']}")
+        if f["endline"] and f["endline"] != f["line"]:
+            parts.append(f"endLine={f['endline']}")
+        title = f"zizmor: {f['rule']}"
+        parts.append(f"title={_escape_wf_property(title)}")
+        msg = f["msg"].replace("\n", " ").strip() or f["rule"]
+        print(f"::{cmd} {','.join(parts)}::{_escape_wf_data(msg)}")
+
+    return 0
+
+
+def regen_workflow(
+    workflow_path: Path | None = None,
+    script_path: Path | None = None,
+) -> int:
+    """Replace the embedded base64 block in the workflow file in place.
+
+    Returns 0 if the workflow already matched (no write needed) or was
+    rewritten, and a non-zero code on hard errors (missing files,
+    missing marker block).
+    """
+    here = Path(__file__).resolve()
+    repo_root = here.parent.parent.parent
+    if script_path is None:
+        script_path = here
+    if workflow_path is None:
+        workflow_path = repo_root / ".github" / "workflows" / "zizmor.yaml"
+
+    if not script_path.is_file():
+        print(f"error: script not found: {script_path}", file=sys.stderr)
+        return 2
+    if not workflow_path.is_file():
+        print(
+            f"error: workflow not found: {workflow_path}", file=sys.stderr
+        )
+        return 2
+
+    source = script_path.read_bytes()
+    b64 = base64.b64encode(source).decode("ascii")
+    chunks = [b64[i:i + 76] for i in range(0, len(b64), 76)]
+    block = "\n".join(_B64_INDENT + c for c in chunks) + "\n"
+
+    workflow = workflow_path.read_text()
+    pattern = re.compile(
+        re.escape(_B64_MARKER)
+        + r"\n(?:"
+        + re.escape(_B64_INDENT)
+        + r"[A-Za-z0-9+/=]+\n)+",
+        re.MULTILINE,
+    )
+    m = pattern.search(workflow)
+    if m is None:
+        print(
+            "error: could not find ZIZMOR_SUMMARY_B64 block in "
+            f"{workflow_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    replacement = _B64_MARKER + "\n" + block
+    new_workflow = workflow[: m.start()] + replacement + workflow[m.end():]
+    if new_workflow == workflow:
+        print(f"unchanged: {workflow_path}")
+        return 0
+    workflow_path.write_text(new_workflow)
+    print(
+        f"rewrote {workflow_path} "
+        f"(embedded {len(source)} bytes, base64 {len(b64)} chars)"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarise a zizmor SARIF report. With no arguments, read "
+            "$ZIZMOR_SARIF and write a markdown summary to "
+            "$GITHUB_STEP_SUMMARY. With --regen-workflow, refresh the "
+            "base64-encoded copy of this script embedded in "
+            ".github/workflows/zizmor.yaml."
+        )
+    )
+    parser.add_argument(
+        "--regen-workflow",
+        action="store_true",
+        help=(
+            "regenerate the embedded base64 in "
+            ".github/workflows/zizmor.yaml from this script and exit"
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.regen_workflow:
+        return regen_workflow()
+    return summarise()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,441 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# GitHub Actions security audit using zizmor.
+#
+# Mode:
+#   - Format: SARIF, uploaded to GitHub code scanning on default-branch
+#     pushes only (i.e. after merge). PR runs are advisory.
+#   - Severity: medium and above (informational/low filtered out)
+#   - Persona: regular (default; high-signal, low-noise)
+#   - Advisory: zizmor exits 0 in SARIF mode, so this workflow does NOT
+#     block merges. Code-scanning alerts can be made blocking later via
+#     a code-scanning ruleset once the existing backlog is resolved.
+
+name: '🌈 Zizmor Scan'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch: {}
+  pull_request: {}
+  push: {}
+
+# Default to no permissions; each job grants the minimum it needs.
+permissions: {}
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: 'Audit workflows'
+    # Skip pushes to non-default branches and tags: the audit produces
+    # no useful output for those events because the upload job is
+    # gated to default-branch pushes. PR and workflow_dispatch events
+    # still run.
+    if: >-
+      github.event_name != 'push'
+      || github.ref_name == github.event.repository.default_branch
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    permissions:
+      # Only the bare minimum for the audit itself: clone the repo
+      # under audit. SARIF upload runs in a separate, gated job.
+      contents: read
+    steps:
+      # Harden the runner used by this workflow.
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Checkout repository under audit'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 'Install uv (provides uvx)'
+        # Disable the uv cache: each run installs zizmor fresh from
+        # PyPI (a small package) and audited repositories generally
+        # do not contain Python lockfiles, so leaving the cache on
+        # produces a noisy "no file matched" warning on every run.
+        # yamllint disable-line rule:line-length
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: 'Run zizmor (SARIF, advisory)'
+        # zizmor reads GH_TOKEN/GITHUB_TOKEN to enable online audits
+        # (e.g. resolving tag references for unpinned-uses checks).
+        # SARIF output causes zizmor to always exit 0; merge-blocking
+        # is delegated to code-scanning rulesets.
+        #
+        # Write to a tmp file and only move the SARIF into place if
+        # zizmor exits cleanly. Direct redirection (`> zizmor.sarif`)
+        # would truncate the destination before the command ran, so a
+        # mid-run failure (network, install, etc.) would leave an
+        # empty/partial file that downstream steps would then try to
+        # parse and upload, masking the real failure.
+        id: 'zizmor'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          set -euo pipefail
+          sarif="${GITHUB_WORKSPACE}/zizmor.sarif"
+          tmp_sarif="$(mktemp -t zizmor.XXXXXX.sarif)"
+          # The zizmor version pin lives in
+          #   .github/dependabot/zizmor-requirements.txt
+          # and is kept current by Dependabot's pip ecosystem. Prefer
+          # a workspace copy when one exists (so the audited repo can
+          # carry its own pin and test pin changes via PR); otherwise
+          # fall back to fetching the file from the canonical
+          # org-wide location on the `main` branch of
+          # lfreleng-actions/.github. Either way the workflow itself
+          # stays free of a static version string.
+          local_pin_file='.github/dependabot/zizmor-requirements.txt'
+          if [ -f "${local_pin_file}" ]; then
+            pin_file="${local_pin_file}"
+            pin_source="workspace (${local_pin_file})"
+          else
+            pin_ref='main'
+            pin_url="https://raw.githubusercontent.com/lfreleng-actions/.github/${pin_ref}/.github/dependabot/zizmor-requirements.txt"
+            pin_file="$(mktemp -t zizmor-pin.XXXXXX.txt)"
+            # Bounded retries + timeouts so a transient network blip
+            # does not hang or spuriously fail the audit.
+            curl --fail --silent --show-error \
+              --retry 3 --retry-delay 2 --retry-connrefused \
+              --connect-timeout 10 --max-time 30 \
+              -o "${pin_file}" "${pin_url}"
+            pin_source="lfreleng-actions/.github@${pin_ref}"
+          fi
+          # `|| true` keeps grep's no-match exit (1) from tripping
+          # `set -e`; the explicit empty check below produces a clearer
+          # error than a bare grep failure.
+          pin="$(grep -E '^zizmor==' "${pin_file}" || true)"
+          if [ -z "${pin}" ]; then
+            echo "error: no zizmor pin found in ${pin_source}" >&2
+            exit 2
+          fi
+          echo "Using ${pin} (from ${pin_source})"
+          uvx --from "${pin}" zizmor \
+            --persona=regular \
+            --min-severity=medium \
+            --format=sarif \
+            . > "${tmp_sarif}"
+          # Cheap structural sanity check before publishing the file.
+          python3 -c 'import json,sys; json.load(open(sys.argv[1]))' \
+            "${tmp_sarif}"
+          mv "${tmp_sarif}" "${sarif}"
+          bytes=$(wc -c < "${sarif}" | tr -d ' ')
+          echo "Wrote ${sarif} (${bytes} bytes)"
+          echo '::group::SARIF preview (first 40 lines)'
+          head -n 40 "${sarif}" || true
+          echo '::endgroup::'
+
+      - name: 'Summarise zizmor findings'
+        # Parse the SARIF locally and write a human-readable summary
+        # to GITHUB_STEP_SUMMARY so every run has visible output, not
+        # just default-branch pushes (which also publish to code
+        # scanning). Also emits workflow-command annotations for the
+        # top findings so they surface as inline PR annotations.
+        # Stdlib-only: no pip install, no extra dependencies.
+        #
+        # The Python parser is embedded as base64 so it can be
+        # invoked without checking a script into the audited
+        # repository (this workflow runs as a required workflow
+        # across many repositories that do not contain it). Edit the
+        # source at .github/scripts/zizmor_summary.py and regenerate
+        # the embedded copy by running:
+        #
+        #   python3 .github/scripts/zizmor_summary.py --regen-workflow
+        #
+        # then commit both files together.
+        if: >-
+          always()
+          && steps.zizmor.outcome == 'success'
+          && hashFiles('zizmor.sarif') != ''
+        env:
+          ZIZMOR_SARIF: '${{ github.workspace }}/zizmor.sarif'
+          ZIZMOR_PERSONA: 'regular'
+          ZIZMOR_MIN_SEVERITY: 'medium'
+          # Maximum number of findings to render in the detail table
+          # and as inline PR annotations. Counts and rule histogram
+          # always cover the full set.
+          ZIZMOR_TOP_N: '10'
+          ZIZMOR_SUMMARY_B64: |
+            IyBTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogQXBhY2hlLTIuMAojIFNQRFgtRmlsZUNvcHlyaWdo
+            dFRleHQ6IDIwMjYgVGhlIExpbnV4IEZvdW5kYXRpb24KIiIiU3VtbWFyaXNlIGEgeml6bW9yIFNB
+            UklGIHJlcG9ydCBmb3IgdGhlIEdpdEh1YiBBY3Rpb25zIHN0ZXAgc3VtbWFyeS4KCkRlZmF1bHQg
+            bW9kZSAobm8gYXJndW1lbnRzKTogcmVhZCB0aGUgU0FSSUYgZmlsZSBhdCBgYCRaSVpNT1JfU0FS
+            SUZgYAphbmQgd3JpdGUgYSBodW1hbi1yZWFkYWJsZSBtYXJrZG93biBzdW1tYXJ5IHRvIGBgJEdJ
+            VEhVQl9TVEVQX1NVTU1BUllgYC4KQWxzbyBlbWl0IGEgY29tcGFjdCBsaXN0aW5nIHRvIHN0ZG91
+            dCBhbmQKYGA6Ondhcm5pbmdgYC9gYDo6ZXJyb3JgYC9gYDo6bm90aWNlYGAgd29ya2Zsb3cgY29t
+            bWFuZHMgZm9yIHRoZSB0b3AKZmluZGluZ3Mgc28gdGhleSBzdXJmYWNlIGFzIGlubGluZSBQUiBh
+            bm5vdGF0aW9ucy4KCkhlbHBlciBtb2RlIChgYC0tcmVnZW4td29ya2Zsb3dgYCk6IHJlZ2VuZXJh
+            dGUgdGhlIGJhc2U2NC1lbmNvZGVkIGNvcHkKb2YgdGhpcyBzY3JpcHQgdGhhdCBsaXZlcyBpbiBg
+            YC5naXRodWIvd29ya2Zsb3dzL3ppem1vci55YW1sYGAgdW5kZXIKYGBlbnYuWklaTU9SX1NVTU1B
+            UllfQjY0YGAuIFRoZSB3b3JrZmxvdyBmaWxlIGVtYmVkcyB0aGUgcGFyc2VyIGFzCmJhc2U2NCBi
+            ZWNhdXNlIGl0IGlzIGludm9rZWQgYXMgYSByZXF1aXJlZCB3b3JrZmxvdyBhZ2FpbnN0IHJlcG9z
+            IHRoYXQKZG8gbm90IGNvbnRhaW4gdGhpcyBzY3JpcHQuIEFmdGVyIGVkaXRpbmcgdGhpcyBmaWxl
+            LCBydW46OgoKICAgIHB5dGhvbjMgLmdpdGh1Yi9zY3JpcHRzL3ppem1vcl9zdW1tYXJ5LnB5IC0t
+            cmVnZW4td29ya2Zsb3cKCnRoZW4gY29tbWl0IGJvdGggZmlsZXMgdG9nZXRoZXIuCiIiIgppbXBv
+            cnQgYXJncGFyc2UKaW1wb3J0IGJhc2U2NAppbXBvcnQganNvbgppbXBvcnQgb3MKaW1wb3J0IHJl
+            CmltcG9ydCBzeXMKZnJvbSBjb2xsZWN0aW9ucyBpbXBvcnQgQ291bnRlcgpmcm9tIHBhdGhsaWIg
+            aW1wb3J0IFBhdGgKZnJvbSBwb3NpeHBhdGggaW1wb3J0IGJhc2VuYW1lCmZyb20gdXJsbGliLnBh
+            cnNlIGltcG9ydCBxdW90ZQoKIyBNYXJrZXIgdXNlZCBieSAtLXJlZ2VuLXdvcmtmbG93IHRvIGxv
+            Y2F0ZSB0aGUgZW1iZWRkZWQgYmFzZTY0IGJsb2NrLgpfQjY0X01BUktFUiA9ICJaSVpNT1JfU1VN
+            TUFSWV9CNjQ6IHwiCl9CNjRfSU5ERU5UID0gIiAiICogMTIKCkxFVkVMX0xBQkVMID0gewogICAg
+            ImVycm9yIjogIlx1MjZkNCBIaWdoIiwKICAgICJ3YXJuaW5nIjogIlx1MjZhMFx1ZmUwZiBNZWRp
+            dW0iLAogICAgIm5vdGUiOiAiXFUwMDAxZjRkZCBMb3ciLAogICAgIm5vbmUiOiAiXHUyMTM5XHVm
+            ZTBmIEluZm8iLAp9CkxFVkVMX09SREVSID0gWyJlcnJvciIsICJ3YXJuaW5nIiwgIm5vdGUiLCAi
+            bm9uZSJdCldBUk5fQ01EID0gewogICAgImVycm9yIjogImVycm9yIiwgIndhcm5pbmciOiAid2Fy
+            bmluZyIsCiAgICAibm90ZSI6ICJub3RpY2UiLCAibm9uZSI6ICJub3RpY2UiLAp9CgoKZGVmIHN0
+            cmlwX3J1bGVfcHJlZml4KHJpZDogc3RyKSAtPiBzdHI6CiAgICAiIiJEcm9wIHRoZSBgYHppem1v
+            ci9gYCBwcmVmaXggZnJvbSBhIHJ1bGUgaWQgZm9yIHRpZ2h0ZXIgdGFibGVzLiIiIgogICAgaWYg
+            cmlkLnN0YXJ0c3dpdGgoInppem1vci8iKToKICAgICAgICByZXR1cm4gcmlkW2xlbigieml6bW9y
+            LyIpOl0KICAgIHJldHVybiByaWQKCgpkZWYgX2VzY2FwZV93Zl9kYXRhKHZhbHVlOiBvYmplY3Qp
+            IC0+IHN0cjoKICAgICIiIkVzY2FwZSB0aGUgbWVzc2FnZSBib2R5IG9mIGEgR2l0SHViIHdvcmtm
+            bG93IGNvbW1hbmQuCgogICAgUGVyIEdpdEh1YidzIHdvcmtmbG93LWNvbW1hbmQgcnVsZXMsIGBg
+            JWBgLCBgYENSYGAgYW5kIGBgTEZgYCBtdXN0CiAgICBiZSBwZXJjZW50LWVuY29kZWQgaW4gdGhl
+            IGRhdGEgKHBvc3QtYGA6OmBgKSBwb3J0aW9uLgogICAgIiIiCiAgICByZXR1cm4gKAogICAgICAg
+            IHN0cih2YWx1ZSkKICAgICAgICAucmVwbGFjZSgiJSIsICIlMjUiKQogICAgICAgIC5yZXBsYWNl
+            KCJcciIsICIlMEQiKQogICAgICAgIC5yZXBsYWNlKCJcbiIsICIlMEEiKQogICAgKQoKCmRlZiBf
+            ZXNjYXBlX3dmX3Byb3BlcnR5KHZhbHVlOiBvYmplY3QpIC0+IHN0cjoKICAgICIiIkVzY2FwZSBh
+            IHByb3BlcnR5IHZhbHVlIG9mIGEgR2l0SHViIHdvcmtmbG93IGNvbW1hbmQuCgogICAgUHJvcGVy
+            dGllcyBsaXZlIGluIHRoZSBjb21tYS1zZXBhcmF0ZWQgYGBrZXk9dmFsdWVgYCBsaXN0IGJlZm9y
+            ZQogICAgYGA6OmBgLiBJbiBhZGRpdGlvbiB0byB0aGUgZGF0YS1lc2NhcGVzLCBgYCxgYCBhbmQg
+            YGA6YGAgbXVzdCBiZQogICAgZW5jb2RlZCBzbyB0aGV5IGNhbm5vdCB0ZXJtaW5hdGUgdGhlIHBy
+            b3BlcnR5IGxpc3Qgb3IgdGhlIGNvbW1hbmQKICAgIHByZWZpeC4KICAgICIiIgogICAgcmV0dXJu
+            ICgKICAgICAgICBfZXNjYXBlX3dmX2RhdGEodmFsdWUpCiAgICAgICAgLnJlcGxhY2UoIjoiLCAi
+            JTNBIikKICAgICAgICAucmVwbGFjZSgiLCIsICIlMkMiKQogICAgKQoKCmRlZiBfcmVuZGVyX2xp
+            bmsoZmlsZTogc3RyLCBsaW5lLCByZXBvOiBzdHIsIHNoYTogc3RyLCBzZXJ2ZXI6IHN0cikgLT4g
+            c3RyOgogICAgIiIiUmVuZGVyIGEgcGF0aDpsaW5lIGxpbmsgd2l0aCB0aGUgYmFzZW5hbWUgYXMg
+            dmlzaWJsZSB0ZXh0LiIiIgogICAgaWYgbm90IGZpbGU6CiAgICAgICAgcmV0dXJuICIiCiAgICBz
+            aG9ydCA9IGJhc2VuYW1lKGZpbGUpIG9yIGZpbGUKICAgIGxhYmVsID0gc2hvcnQgKyAoZiI6e2xp
+            bmV9IiBpZiBsaW5lIGVsc2UgIiIpCiAgICBpZiBub3QgcmVwbyBvciBub3Qgc2hhOgogICAgICAg
+            IHJldHVybiBmImB7bGFiZWx9YCIKICAgIGFuY2hvciA9IGYiI0x7bGluZX0iIGlmIGxpbmUgZWxz
+            ZSAiIgogICAgdXJsID0gZiJ7c2VydmVyfS97cmVwb30vYmxvYi97c2hhfS97cXVvdGUoZmlsZSl9
+            e2FuY2hvcn0iCiAgICByZXR1cm4gZiJbYHtsYWJlbH1gXSh7dXJsfSkiCgoKZGVmIF9sb2FkX2Zp
+            bmRpbmdzKHNhcmlmX3BhdGg6IFBhdGgpOgogICAgIiIiUGFyc2UgU0FSSUYgYW5kIHJldHVybiAo
+            ZmluZGluZ3MsIGxldmVsX2NvdW50cywgcnVsZV9jb3VudHMpLiIiIgogICAgd2l0aCBzYXJpZl9w
+            YXRoLm9wZW4oKSBhcyBmaDoKICAgICAgICBkYXRhID0ganNvbi5sb2FkKGZoKQoKICAgIGZpbmRp
+            bmdzID0gW10KICAgIHJ1bGVfbWV0YSA9IHt9CiAgICBmb3IgcnVuIGluIGRhdGEuZ2V0KCJydW5z
+            IiwgW10pOgogICAgICAgIHRvb2wgPSBydW4uZ2V0KCJ0b29sIiwge30pLmdldCgiZHJpdmVyIiwg
+            e30pCiAgICAgICAgZm9yIHJ1bGUgaW4gdG9vbC5nZXQoInJ1bGVzIiwgW10pOgogICAgICAgICAg
+            ICBydWxlX21ldGFbcnVsZS5nZXQoImlkIiwgIiIpXSA9IHJ1bGUKICAgICAgICBmb3IgcmVzdWx0
+            IGluIHJ1bi5nZXQoInJlc3VsdHMiLCBbXSk6CiAgICAgICAgICAgIHJpZCA9IHJlc3VsdC5nZXQo
+            InJ1bGVJZCIsICI/IikKICAgICAgICAgICAgbGV2ZWwgPSAoCiAgICAgICAgICAgICAgICByZXN1
+            bHQuZ2V0KCJsZXZlbCIpCiAgICAgICAgICAgICAgICBvciBydWxlX21ldGEuZ2V0KHJpZCwge30p
+            CiAgICAgICAgICAgICAgICAgICAgLmdldCgiZGVmYXVsdENvbmZpZ3VyYXRpb24iLCB7fSkKICAg
+            ICAgICAgICAgICAgICAgICAuZ2V0KCJsZXZlbCIsICJ3YXJuaW5nIikKICAgICAgICAgICAgKQog
+            ICAgICAgICAgICBtc2cgPSAocmVzdWx0LmdldCgibWVzc2FnZSIpIG9yIHt9KS5nZXQoInRleHQi
+            LCAiIikuc3RyaXAoKQogICAgICAgICAgICBsb2MgPSAocmVzdWx0LmdldCgibG9jYXRpb25zIikg
+            b3IgW3t9XSlbMF0KICAgICAgICAgICAgcGxvYyA9IGxvYy5nZXQoInBoeXNpY2FsTG9jYXRpb24i
+            LCB7fSkKICAgICAgICAgICAgYXJ0aWZhY3QgPSBwbG9jLmdldCgiYXJ0aWZhY3RMb2NhdGlvbiIs
+            IHt9KS5nZXQoInVyaSIsICIiKQogICAgICAgICAgICByZWdpb24gPSBwbG9jLmdldCgicmVnaW9u
+            Iiwge30pIG9yIHt9CiAgICAgICAgICAgIGxpbmUgPSByZWdpb24uZ2V0KCJzdGFydExpbmUiKQog
+            ICAgICAgICAgICBlbmRsaW5lID0gcmVnaW9uLmdldCgiZW5kTGluZSIpIG9yIGxpbmUKICAgICAg
+            ICAgICAgZmluZGluZ3MuYXBwZW5kKHsKICAgICAgICAgICAgICAgICJydWxlIjogcmlkLAogICAg
+            ICAgICAgICAgICAgImxldmVsIjogbGV2ZWwsCiAgICAgICAgICAgICAgICAibXNnIjogbXNnLAog
+            ICAgICAgICAgICAgICAgImZpbGUiOiBhcnRpZmFjdCwKICAgICAgICAgICAgICAgICJsaW5lIjog
+            bGluZSwKICAgICAgICAgICAgICAgICJlbmRsaW5lIjogZW5kbGluZSwKICAgICAgICAgICAgfSkK
+            CiAgICBkZWYgc29ydF9rZXkoZik6CiAgICAgICAgdHJ5OgogICAgICAgICAgICBpZHggPSBMRVZF
+            TF9PUkRFUi5pbmRleChmWyJsZXZlbCJdKQogICAgICAgIGV4Y2VwdCBWYWx1ZUVycm9yOgogICAg
+            ICAgICAgICBpZHggPSA5OQogICAgICAgIHJldHVybiAoaWR4LCBmWyJydWxlIl0sIGZbImZpbGUi
+            XSwgZlsibGluZSJdIG9yIDApCgogICAgZmluZGluZ3Muc29ydChrZXk9c29ydF9rZXkpCiAgICBs
+            ZXZlbF9jb3VudHMgPSBDb3VudGVyKGZbImxldmVsIl0gZm9yIGYgaW4gZmluZGluZ3MpCiAgICBy
+            dWxlX2NvdW50cyA9IENvdW50ZXIoZlsicnVsZSJdIGZvciBmIGluIGZpbmRpbmdzKQogICAgcmV0
+            dXJuIGZpbmRpbmdzLCBsZXZlbF9jb3VudHMsIHJ1bGVfY291bnRzCgoKZGVmIHN1bW1hcmlzZSgp
+            IC0+IGludDoKICAgICIiIlJlYWQgU0FSSUYgYW5kIHdyaXRlIHN1bW1hcnk7IHJldHVybiBwcm9j
+            ZXNzIGV4aXQgY29kZS4iIiIKICAgIHNhcmlmX3BhdGggPSBQYXRoKG9zLmVudmlyb25bIlpJWk1P
+            Ul9TQVJJRiJdKQogICAgdG9wX24gPSBpbnQob3MuZW52aXJvbi5nZXQoIlpJWk1PUl9UT1BfTiIs
+            ICIxMCIpKQogICAgc3VtbWFyeV9wYXRoID0gb3MuZW52aXJvbi5nZXQoIkdJVEhVQl9TVEVQX1NV
+            TU1BUlkiKQogICAgc2VydmVyID0gb3MuZW52aXJvbi5nZXQoIkdJVEhVQl9TRVJWRVJfVVJMIiwg
+            Imh0dHBzOi8vZ2l0aHViLmNvbSIpCiAgICByZXBvID0gb3MuZW52aXJvbi5nZXQoIkdJVEhVQl9S
+            RVBPU0lUT1JZIiwgIiIpCiAgICBzaGEgPSBvcy5lbnZpcm9uLmdldCgiR0lUSFVCX1NIQSIsICIi
+            KQogICAgcGVyc29uYSA9IG9zLmVudmlyb24uZ2V0KCJaSVpNT1JfUEVSU09OQSIsICJyZWd1bGFy
+            IikKICAgIG1pbl9zZXZlcml0eSA9IG9zLmVudmlyb24uZ2V0KCJaSVpNT1JfTUlOX1NFVkVSSVRZ
+            IiwgIm1lZGl1bSIpCgogICAgZmluZGluZ3MsIGxldmVsX2NvdW50cywgcnVsZV9jb3VudHMgPSBf
+            bG9hZF9maW5kaW5ncyhzYXJpZl9wYXRoKQogICAgdG90YWwgPSBzdW0obGV2ZWxfY291bnRzLnZh
+            bHVlcygpKQogICAgc2hvcnRfc2hhID0gc2hhWzo3XSBpZiBzaGEgZWxzZSAiPyIKCiAgICBvdXQg
+            PSBbIiMgXFUwMDAxZjMwOCBaaXptb3IgU2NhbiIsICIiXQogICAgaWYgdG90YWwgPT0gMDoKICAg
+            ICAgICBvdXQuYXBwZW5kKGYiTm8gZmluZGluZ3MgYXQgb3IgYWJvdmUgYHttaW5fc2V2ZXJpdHl9
+            YCBcdTI3MDUiKQogICAgZWxzZToKICAgICAgICBvdXQuYXBwZW5kKAogICAgICAgICAgICBmInt0
+            b3RhbH0gZmluZGluZyhzKSBhdCBvciBhYm92ZSBge21pbl9zZXZlcml0eX1gIFx1MjZhMFx1ZmUw
+            ZiIKICAgICAgICApCiAgICBvdXQuZXh0ZW5kKFsKICAgICAgICAiIiwKICAgICAgICBmImB7cmVw
+            b31Ae3Nob3J0X3NoYX1gIiwKICAgICAgICBmInBlcnNvbmE6IGB7cGVyc29uYX1gIiwKICAgICAg
+            ICBmIm1pbi1zZXZlcml0eTogYHttaW5fc2V2ZXJpdHl9YCIsCiAgICAgICAgIiIsCiAgICBdKQoK
+            ICAgIGlmIHRvdGFsID4gMDoKICAgICAgICBvdXQuYXBwZW5kKCIjIyBDb3VudHMgYnkgc2V2ZXJp
+            dHkiKQogICAgICAgIG91dC5hcHBlbmQoIiIpCiAgICAgICAgb3V0LmFwcGVuZCgifCBTZXZlcml0
+            eSB8IENvdW50IHwiKQogICAgICAgIG91dC5hcHBlbmQoInwgLS0tIHwgLS0tOiB8IikKICAgICAg
+            ICBmb3IgbHZsIGluIExFVkVMX09SREVSOgogICAgICAgICAgICBpZiBsdmwgaW4gbGV2ZWxfY291
+            bnRzOgogICAgICAgICAgICAgICAgb3V0LmFwcGVuZCgKICAgICAgICAgICAgICAgICAgICBmInwg
+            e0xFVkVMX0xBQkVMLmdldChsdmwsIGx2bCl9IHwge2xldmVsX2NvdW50c1tsdmxdfSB8IgogICAg
+            ICAgICAgICAgICAgKQogICAgICAgIG91dC5hcHBlbmQoIiIpCiAgICAgICAgb3V0LmFwcGVuZCgi
+            IyMgQ291bnRzIGJ5IHJ1bGUiKQogICAgICAgIG91dC5hcHBlbmQoIiIpCiAgICAgICAgb3V0LmFw
+            cGVuZCgifCBSdWxlIHwgQ291bnQgfCIpCiAgICAgICAgb3V0LmFwcGVuZCgifCAtLS0gfCAtLS06
+            IHwiKQogICAgICAgIGZvciByaWQsIG4gaW4gcnVsZV9jb3VudHMubW9zdF9jb21tb24oKToKICAg
+            ICAgICAgICAgb3V0LmFwcGVuZChmInwgYHtzdHJpcF9ydWxlX3ByZWZpeChyaWQpfWAgfCB7bn0g
+            fCIpCiAgICAgICAgb3V0LmFwcGVuZCgiIikKICAgICAgICBzaG93biA9IGZpbmRpbmdzWzp0b3Bf
+            bl0KICAgICAgICBleHRyYSA9IHRvdGFsIC0gbGVuKHNob3duKQogICAgICAgIGhlYWRpbmcgPSBm
+            IiMjIFRvcCB7bGVuKHNob3duKX0gZmluZGluZ3MiCiAgICAgICAgaWYgZXh0cmEgPiAwOgogICAg
+            ICAgICAgICBoZWFkaW5nICs9IGYiIChvZiB7dG90YWx9OyB7ZXh0cmF9IG1vcmUgaW4gU0FSSUYp
+            IgogICAgICAgIG91dC5hcHBlbmQoaGVhZGluZykKICAgICAgICBvdXQuYXBwZW5kKCIiKQogICAg
+            ICAgIG91dC5hcHBlbmQoInwgU2V2ZXJpdHkgfCBSdWxlIHwgTG9jYXRpb24gfCBNZXNzYWdlIHwi
+            KQogICAgICAgIG91dC5hcHBlbmQoInwgLS0tIHwgLS0tIHwgLS0tIHwgLS0tIHwiKQogICAgICAg
+            IGZvciBmIGluIHNob3duOgogICAgICAgICAgICBsYWJlbCA9IExFVkVMX0xBQkVMLmdldChmWyJs
+            ZXZlbCJdLCBmWyJsZXZlbCJdKQogICAgICAgICAgICBtc2cgPSBmWyJtc2ciXS5yZXBsYWNlKCJ8
+            IiwgIlxcfCIpLnJlcGxhY2UoIlxuIiwgIiAiKQogICAgICAgICAgICBpZiBsZW4obXNnKSA+IDIw
+            MDoKICAgICAgICAgICAgICAgIG1zZyA9IG1zZ1s6MTk3XSArICIuLi4iCiAgICAgICAgICAgIHJ1
+            bGVfc2hvcnQgPSBzdHJpcF9ydWxlX3ByZWZpeChmWyJydWxlIl0pCiAgICAgICAgICAgIGxvYyA9
+            IF9yZW5kZXJfbGluayhmWyJmaWxlIl0sIGZbImxpbmUiXSwgcmVwbywgc2hhLCBzZXJ2ZXIpCiAg
+            ICAgICAgICAgIG91dC5hcHBlbmQoCiAgICAgICAgICAgICAgICBmInwge2xhYmVsfSB8IGB7cnVs
+            ZV9zaG9ydH1gIHwge2xvY30gfCB7bXNnfSB8IgogICAgICAgICAgICApCgogICAgc3VtbWFyeSA9
+            ICJcbiIuam9pbihvdXQpICsgIlxuIgogICAgaWYgc3VtbWFyeV9wYXRoOgogICAgICAgIHdpdGgg
+            b3BlbihzdW1tYXJ5X3BhdGgsICJhIiwgZW5jb2Rpbmc9InV0Zi04IikgYXMgZmg6CiAgICAgICAg
+            ICAgIGZoLndyaXRlKHN1bW1hcnkpCgogICAgcHJpbnQoIjo6Z3JvdXA6Onppem1vciBzdW1tYXJ5
+            IikKICAgIGJ5X2xldmVsID0ge0xFVkVMX0xBQkVMLmdldChrLCBrKTogdiBmb3IgaywgdiBpbiBs
+            ZXZlbF9jb3VudHMuaXRlbXMoKX0KICAgIHByaW50KAogICAgICAgIGYiVG90YWw6IHt0b3RhbH0g
+            IGJ5LWxldmVsOiB7YnlfbGV2ZWx9ICBydWxlczoge2xlbihydWxlX2NvdW50cyl9IgogICAgKQog
+            ICAgZm9yIGYgaW4gZmluZGluZ3NbOnRvcF9uXToKICAgICAgICBsYWJlbCA9IExFVkVMX0xBQkVM
+            LmdldChmWyJsZXZlbCJdLCBmWyJsZXZlbCJdKQogICAgICAgIGxvY19zdHIgPSBmWyJmaWxlIl0g
+            KyAoZiI6e2ZbJ2xpbmUnXX0iIGlmIGZbImxpbmUiXSBlbHNlICIiKQogICAgICAgIHJ1bGVfc2hv
+            cnQgPSBzdHJpcF9ydWxlX3ByZWZpeChmWyJydWxlIl0pCiAgICAgICAgcHJpbnQoZiIgIHtsYWJl
+            bH0gIHtydWxlX3Nob3J0OjwyOH0gIHtsb2Nfc3RyfSIpCiAgICBwcmludCgiOjplbmRncm91cDo6
+            IikKCiAgICAjIFdvcmtmbG93IGNvbW1hbmRzIGtlZXAgdGhlIGZ1bGwgcnVsZSBpZCBpbiB0aGUg
+            dGl0bGUgc2luY2UKICAgICMgR2l0SHViIHNob3dzIHRoZW0gb3V0IG9mIGNvbnRleHQgKGUuZy4g
+            aW4gUFIgZmlsZSBhbm5vdGF0aW9ucykuCiAgICAjIFByb3BlcnR5IHZhbHVlcyBhcmUgZXNjYXBl
+            ZCBwZXIgR2l0SHViJ3Mgd29ya2Zsb3ctY29tbWFuZCBydWxlcwogICAgIyBzbyBgYCxgYCBhbmQg
+            YGA6YGAgaW4gdGl0bGVzIG9yIHBhdGhzIGNhbm5vdCBicmVhayB0aGUgZm9ybWF0LgogICAgZm9y
+            IGYgaW4gZmluZGluZ3NbOnRvcF9uXToKICAgICAgICBjbWQgPSBXQVJOX0NNRC5nZXQoZlsibGV2
+            ZWwiXSwgIndhcm5pbmciKQogICAgICAgIHBhcnRzID0gW10KICAgICAgICBpZiBmWyJmaWxlIl06
+            CiAgICAgICAgICAgIHBhcnRzLmFwcGVuZChmImZpbGU9e19lc2NhcGVfd2ZfcHJvcGVydHkoZlsn
+            ZmlsZSddKX0iKQogICAgICAgIGlmIGZbImxpbmUiXToKICAgICAgICAgICAgcGFydHMuYXBwZW5k
+            KGYibGluZT17ZlsnbGluZSddfSIpCiAgICAgICAgaWYgZlsiZW5kbGluZSJdIGFuZCBmWyJlbmRs
+            aW5lIl0gIT0gZlsibGluZSJdOgogICAgICAgICAgICBwYXJ0cy5hcHBlbmQoZiJlbmRMaW5lPXtm
+            WydlbmRsaW5lJ119IikKICAgICAgICB0aXRsZSA9IGYieml6bW9yOiB7ZlsncnVsZSddfSIKICAg
+            ICAgICBwYXJ0cy5hcHBlbmQoZiJ0aXRsZT17X2VzY2FwZV93Zl9wcm9wZXJ0eSh0aXRsZSl9IikK
+            ICAgICAgICBtc2cgPSBmWyJtc2ciXS5yZXBsYWNlKCJcbiIsICIgIikuc3RyaXAoKSBvciBmWyJy
+            dWxlIl0KICAgICAgICBwcmludChmIjo6e2NtZH0geycsJy5qb2luKHBhcnRzKX06OntfZXNjYXBl
+            X3dmX2RhdGEobXNnKX0iKQoKICAgIHJldHVybiAwCgoKZGVmIHJlZ2VuX3dvcmtmbG93KAogICAg
+            d29ya2Zsb3dfcGF0aDogUGF0aCB8IE5vbmUgPSBOb25lLAogICAgc2NyaXB0X3BhdGg6IFBhdGgg
+            fCBOb25lID0gTm9uZSwKKSAtPiBpbnQ6CiAgICAiIiJSZXBsYWNlIHRoZSBlbWJlZGRlZCBiYXNl
+            NjQgYmxvY2sgaW4gdGhlIHdvcmtmbG93IGZpbGUgaW4gcGxhY2UuCgogICAgUmV0dXJucyAwIGlm
+            IHRoZSB3b3JrZmxvdyBhbHJlYWR5IG1hdGNoZWQgKG5vIHdyaXRlIG5lZWRlZCkgb3Igd2FzCiAg
+            ICByZXdyaXR0ZW4sIGFuZCBhIG5vbi16ZXJvIGNvZGUgb24gaGFyZCBlcnJvcnMgKG1pc3Npbmcg
+            ZmlsZXMsCiAgICBtaXNzaW5nIG1hcmtlciBibG9jaykuCiAgICAiIiIKICAgIGhlcmUgPSBQYXRo
+            KF9fZmlsZV9fKS5yZXNvbHZlKCkKICAgIHJlcG9fcm9vdCA9IGhlcmUucGFyZW50LnBhcmVudC5w
+            YXJlbnQKICAgIGlmIHNjcmlwdF9wYXRoIGlzIE5vbmU6CiAgICAgICAgc2NyaXB0X3BhdGggPSBo
+            ZXJlCiAgICBpZiB3b3JrZmxvd19wYXRoIGlzIE5vbmU6CiAgICAgICAgd29ya2Zsb3dfcGF0aCA9
+            IHJlcG9fcm9vdCAvICIuZ2l0aHViIiAvICJ3b3JrZmxvd3MiIC8gInppem1vci55YW1sIgoKICAg
+            IGlmIG5vdCBzY3JpcHRfcGF0aC5pc19maWxlKCk6CiAgICAgICAgcHJpbnQoZiJlcnJvcjogc2Ny
+            aXB0IG5vdCBmb3VuZDoge3NjcmlwdF9wYXRofSIsIGZpbGU9c3lzLnN0ZGVycikKICAgICAgICBy
+            ZXR1cm4gMgogICAgaWYgbm90IHdvcmtmbG93X3BhdGguaXNfZmlsZSgpOgogICAgICAgIHByaW50
+            KAogICAgICAgICAgICBmImVycm9yOiB3b3JrZmxvdyBub3QgZm91bmQ6IHt3b3JrZmxvd19wYXRo
+            fSIsIGZpbGU9c3lzLnN0ZGVycgogICAgICAgICkKICAgICAgICByZXR1cm4gMgoKICAgIHNvdXJj
+            ZSA9IHNjcmlwdF9wYXRoLnJlYWRfYnl0ZXMoKQogICAgYjY0ID0gYmFzZTY0LmI2NGVuY29kZShz
+            b3VyY2UpLmRlY29kZSgiYXNjaWkiKQogICAgY2h1bmtzID0gW2I2NFtpOmkgKyA3Nl0gZm9yIGkg
+            aW4gcmFuZ2UoMCwgbGVuKGI2NCksIDc2KV0KICAgIGJsb2NrID0gIlxuIi5qb2luKF9CNjRfSU5E
+            RU5UICsgYyBmb3IgYyBpbiBjaHVua3MpICsgIlxuIgoKICAgIHdvcmtmbG93ID0gd29ya2Zsb3df
+            cGF0aC5yZWFkX3RleHQoKQogICAgcGF0dGVybiA9IHJlLmNvbXBpbGUoCiAgICAgICAgcmUuZXNj
+            YXBlKF9CNjRfTUFSS0VSKQogICAgICAgICsgciJcbig/OiIKICAgICAgICArIHJlLmVzY2FwZShf
+            QjY0X0lOREVOVCkKICAgICAgICArIHIiW0EtWmEtejAtOSsvPV0rXG4pKyIsCiAgICAgICAgcmUu
+            TVVMVElMSU5FLAogICAgKQogICAgbSA9IHBhdHRlcm4uc2VhcmNoKHdvcmtmbG93KQogICAgaWYg
+            bSBpcyBOb25lOgogICAgICAgIHByaW50KAogICAgICAgICAgICAiZXJyb3I6IGNvdWxkIG5vdCBm
+            aW5kIFpJWk1PUl9TVU1NQVJZX0I2NCBibG9jayBpbiAiCiAgICAgICAgICAgIGYie3dvcmtmbG93
+            X3BhdGh9IiwKICAgICAgICAgICAgZmlsZT1zeXMuc3RkZXJyLAogICAgICAgICkKICAgICAgICBy
+            ZXR1cm4gMgoKICAgIHJlcGxhY2VtZW50ID0gX0I2NF9NQVJLRVIgKyAiXG4iICsgYmxvY2sKICAg
+            IG5ld193b3JrZmxvdyA9IHdvcmtmbG93WzogbS5zdGFydCgpXSArIHJlcGxhY2VtZW50ICsgd29y
+            a2Zsb3dbbS5lbmQoKTpdCiAgICBpZiBuZXdfd29ya2Zsb3cgPT0gd29ya2Zsb3c6CiAgICAgICAg
+            cHJpbnQoZiJ1bmNoYW5nZWQ6IHt3b3JrZmxvd19wYXRofSIpCiAgICAgICAgcmV0dXJuIDAKICAg
+            IHdvcmtmbG93X3BhdGgud3JpdGVfdGV4dChuZXdfd29ya2Zsb3cpCiAgICBwcmludCgKICAgICAg
+            ICBmInJld3JvdGUge3dvcmtmbG93X3BhdGh9ICIKICAgICAgICBmIihlbWJlZGRlZCB7bGVuKHNv
+            dXJjZSl9IGJ5dGVzLCBiYXNlNjQge2xlbihiNjQpfSBjaGFycykiCiAgICApCiAgICByZXR1cm4g
+            MAoKCmRlZiBtYWluKGFyZ3Y6IGxpc3Rbc3RyXSB8IE5vbmUgPSBOb25lKSAtPiBpbnQ6CiAgICBw
+            YXJzZXIgPSBhcmdwYXJzZS5Bcmd1bWVudFBhcnNlcigKICAgICAgICBkZXNjcmlwdGlvbj0oCiAg
+            ICAgICAgICAgICJTdW1tYXJpc2UgYSB6aXptb3IgU0FSSUYgcmVwb3J0LiBXaXRoIG5vIGFyZ3Vt
+            ZW50cywgcmVhZCAiCiAgICAgICAgICAgICIkWklaTU9SX1NBUklGIGFuZCB3cml0ZSBhIG1hcmtk
+            b3duIHN1bW1hcnkgdG8gIgogICAgICAgICAgICAiJEdJVEhVQl9TVEVQX1NVTU1BUlkuIFdpdGgg
+            LS1yZWdlbi13b3JrZmxvdywgcmVmcmVzaCB0aGUgIgogICAgICAgICAgICAiYmFzZTY0LWVuY29k
+            ZWQgY29weSBvZiB0aGlzIHNjcmlwdCBlbWJlZGRlZCBpbiAiCiAgICAgICAgICAgICIuZ2l0aHVi
+            L3dvcmtmbG93cy96aXptb3IueWFtbC4iCiAgICAgICAgKQogICAgKQogICAgcGFyc2VyLmFkZF9h
+            cmd1bWVudCgKICAgICAgICAiLS1yZWdlbi13b3JrZmxvdyIsCiAgICAgICAgYWN0aW9uPSJzdG9y
+            ZV90cnVlIiwKICAgICAgICBoZWxwPSgKICAgICAgICAgICAgInJlZ2VuZXJhdGUgdGhlIGVtYmVk
+            ZGVkIGJhc2U2NCBpbiAiCiAgICAgICAgICAgICIuZ2l0aHViL3dvcmtmbG93cy96aXptb3IueWFt
+            bCBmcm9tIHRoaXMgc2NyaXB0IGFuZCBleGl0IgogICAgICAgICksCiAgICApCiAgICBhcmdzID0g
+            cGFyc2VyLnBhcnNlX2FyZ3MoYXJndikKICAgIGlmIGFyZ3MucmVnZW5fd29ya2Zsb3c6CiAgICAg
+            ICAgcmV0dXJuIHJlZ2VuX3dvcmtmbG93KCkKICAgIHJldHVybiBzdW1tYXJpc2UoKQoKCmlmIF9f
+            bmFtZV9fID09ICJfX21haW5fXyI6CiAgICBzeXMuZXhpdChtYWluKCkpCg==
+        run: |
+          set -euo pipefail
+          script="$(mktemp -t zizmor_summary.XXXXXX.py)"
+          printf '%s' "${ZIZMOR_SUMMARY_B64}" | base64 -d > "${script}"
+          python3 "${script}"
+          rm -f "${script}"
+
+      - name: 'Upload SARIF artifact for downstream job'
+        # Only upload the artifact on default-branch pushes; on PRs
+        # and feature-branch pushes there is no consumer for it.
+        if: >-
+          always()
+          && steps.zizmor.outcome == 'success'
+          && hashFiles('zizmor.sarif') != ''
+          && github.event_name == 'push'
+          && github.ref_name == github.event.repository.default_branch
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: 'zizmor-sarif'
+          path: 'zizmor.sarif'
+          retention-days: 1
+          if-no-files-found: 'error'
+
+  upload-sarif:
+    name: 'Upload SARIF to GitHub'
+    needs: 'audit'
+    # Only run after default-branch pushes. PR runs and feature-branch
+    # pushes do not reach this job, so the elevated permissions below
+    # are never granted to those events. This matters most for fork
+    # PRs, where GITHUB_TOKEN does not get security-events: write.
+    if: >-
+      github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    permissions:
+      # Required for github/codeql-action/upload-sarif to publish
+      # results to the repository's code-scanning alerts.
+      security-events: write
+      # Needed for upload-sarif to read workflow run information on
+      # private repositories. Harmless for public repositories.
+      actions: read
+    steps:
+      # Harden the runner used by this workflow.
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Download SARIF artifact'
+        # Set an explicit `path:` so the SARIF lands at a predictable
+        # location regardless of the artifact name. Without this,
+        # download-artifact would extract under `./zizmor-sarif/` and
+        # the upload-sarif step's `sarif_file:` would not find it.
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: 'zizmor-sarif'
+          path: '.'
+
+      - name: 'Upload SARIF to code scanning'
+        # continue-on-error so a transient upload failure does not
+        # block other required checks on the calling repository.
+        continue-on-error: true
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+        with:
+          sarif_file: 'zizmor.sarif'
+          category: 'zizmor'


### PR DESCRIPTION
Already tested/implemented for `lfit/dependamerge` and can now be deployed in the `actions-template` repository so that all future actions are audited at time of creation.