### PR TITLE
Fix: disable credential persistence in testing

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Perform setup prior to running test(s)
       - name: "Testing setup step"


### PR DESCRIPTION
## Summary

Resolves the single `zizmor` finding in this repository: the checkout
step in `testing.yaml` did not set `persist-credentials: false`, so it
was flagged under the **artipacked** audit (credential persistence
through GitHub Actions artifacts).

The test job only needs the working tree, not a stored token, so this
disables credential persistence — matching every other checkout in the
template's workflows.

## Change
- **`.github/workflows/testing.yaml`** — add `persist-credentials: false`
  to the "Checkout repository" step.

## Validation
- `zizmor .` → **no findings** (previously 1 medium `artipacked`)
- `yamllint` → pass
- pre-commit (`reuse`, `actionlint`, `yamllint`, workflow linters) → pass

> Found while syncing the canonical template workflows into
> `lfreleng-actions/openstack-cron-action` (see that repo's PR #60).
