### PR TITLE
Fix: fetch full history for tag validation

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -34,6 +34,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Full history + tags required so tag-validate-action can read
+          # the pushed tag object and verify its signature.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: 'Verify pushed tag'


### PR DESCRIPTION
## Summary

The `tag-push.yaml` `validate_tag` job checks out with the default
shallow clone, but `lfreleng-actions/tag-validate-action` requires the
full tag history to read the pushed tag object and verify its
signature.

From the action's README:

> ### Repository Checkout
> For local tag validation (tag push events):
> ```yaml
> - uses: actions/checkout@v4
>   with:
>     fetch-depth: 0  # Required to fetch all tags
> ```

With `require_signed: 'ssh,gpg-unverifiable'`, a shallow clone can leave
the tag object unreadable and misclassify the signature (the README also
lists "Tag object unreadable (repository fetch limitation)" as a cause
of a spurious `unsigned` result).

## Change
- **`.github/workflows/tag-push.yaml`** — set `fetch-depth: 0` on the
  `validate_tag` checkout. The `promote_release` job operates via the
  API and does not need full history.

## Validation
- `zizmor`, `yamllint`, `actionlint` → pass
- pre-commit hooks → pass

> Found while syncing the canonical template workflows into
> `lfreleng-actions/openstack-cron-action` (PR #60), where GitHub Copilot
> flagged the same shallow-clone issue. Companion to
> [`actions-template` #190](https://github.com/lfreleng-actions/actions-template/pull/190).
