### PR TITLE
CI(security): Clear all zizmor auditor findings

### DIFF
--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      # Actions cache deletion requires the actions: write scope.
-      actions: write
+      # yamllint disable-line rule:line-length
+      actions: write  # Required to list and delete repository Actions caches
     steps:
       # Harden the runner
       # yamllint disable-line rule:line-length
@@ -59,13 +59,15 @@ jobs:
         id: before
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # List current cache entries (pre-deletion snapshot).
           set -euo pipefail
 
-          echo "Repository: ${{ github.repository }}"
+          echo "Repository: $REPO"
           echo "Key filter: '${KEY_PATTERN:-<none>}'"
           echo "Ref filter: '${REF_FILTER:-<none>}'"
           echo ""
@@ -77,7 +79,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/$REPO/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 
@@ -130,7 +132,7 @@ jobs:
             echo "|----------|-------|"
             echo "| Total entries | $before_count |"
             echo "| Matched | $matched_count |"
-            echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
             echo ""
             # Render user-controlled filter inputs inside a fenced
             # code block. KEY_PATTERN and REF_FILTER are free-form
@@ -173,6 +175,7 @@ jobs:
         id: delete
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # Delete the matched cache IDs unless this is a dry run.
@@ -205,7 +208,7 @@ jobs:
             if gh api \
                 --method DELETE \
                 -H "Accept: application/vnd.github+json" \
-                "/repos/${{ github.repository }}/actions/caches/${cache_id}";
+                "/repos/$REPO/actions/caches/${cache_id}";
             then
               deleted=$((deleted + 1))
             else
@@ -238,6 +241,7 @@ jobs:
         if: always() && steps.before.outputs.matched_count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -250,7 +254,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/$REPO/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -30,11 +30,9 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@b2adc11cd90f0ca72a34202589a06d374b5d8366  # v0.5.0
     permissions:
-      # Needed to read repository contents (checkout, etc.).
-      contents: read
-      # Needed to upload the results to the code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and obtain a Scorecard badge via OIDC.
-      id-token: write
+      contents: read  # Read repository contents (checkout, etc.)
+      # yamllint disable-line rule:line-length
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain Scorecard badge via OIDC
       # Uncomment the permission below if installing in a private repository.
       # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,7 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -13,6 +13,13 @@ on:
 
 permissions: {}
 
+# Serialise repeated runs for the same tag; never cancel an in-flight
+# release promotion. Distinct tags use distinct groups and proceed
+# independently.
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: false
+
 jobs:
   validate_tag:
     name: 'Validate Tag'
@@ -53,7 +60,7 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft release for the tag
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -54,9 +54,11 @@ jobs:
 
       - name: "Validated local action: ${{ github.repository }}"
         shell: bash
+        env:
+          REPO: ${{ github.repository }}
         run: |
           # Local action validation
-          echo "Validated local action: ${{ github.repository }}"
+          echo "Validated local action: $REPO"
           echo "Validation step summary output" >> "$GITHUB_STEP_SUMMARY"
 
       # yamllint disable-line rule:line-length

--- a/action.yaml
+++ b/action.yaml
@@ -35,8 +35,15 @@ runs:
 
         # Write the output using the multiline heredoc format with a random
         # delimiter so that an input containing newlines cannot inject
-        # additional keys into $GITHUB_OUTPUT (output-file injection).
-        delimiter="ghadelim_$(openssl rand -hex 16 2>/dev/null || date +%s%N)"
+        # additional keys into $GITHUB_OUTPUT (output-file injection). The
+        # delimiter is built from shell-builtin randomness (no external
+        # tools such as openssl/uuidgen, which are not guaranteed on
+        # self-hosted runners) and regenerated until it is provably absent
+        # from the value being emitted.
+        delimiter="ghadelim_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
+        while [[ "$input" == *"$delimiter"* ]]; do
+          delimiter="ghadelim_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
+        done
         {
           printf '%s<<%s\n' 'output' "$delimiter"
           printf '%s\n' "$input"


### PR DESCRIPTION
## Summary

Brings the canonical template baseline to **zero findings under the
strictest zizmor persona (`auditor`)**, so repositories generated from
this template start clean at every audit level — not just the default
persona.

Verified with `zizmor 1.25.2`:

```text
zizmor --persona=auditor .   →  No findings to report. Good job!
zizmor .                     →  No findings to report. Good job!
```

## Changes

### `action.yaml` — output-file injection hardening

The template wrote `$GITHUB_OUTPUT` using a heredoc delimiter seeded
from `openssl` with a `date +%s%N` fallback. Two problems:

1. **`openssl` is not guaranteed on self-hosted runners** — the action
   could fall through to the timestamp fallback unexpectedly.
2. The **timestamp fallback is predictable** and performs **no
   collision check** against the value being emitted.

Replaced with a shell-builtin delimiter derived from `$RANDOM`,
regenerated in a loop until it is provably absent from the input value.
No external-tool dependency, works on minimal/self-hosted runners, and
the collision check makes delimiter predictability moot.

### Workflows — remaining auditor-level findings

- **`template-injection`** — route `github.repository` and
  `inputs.dry_run` through step `env:` vars in
  `clear-action-cache.yaml` and `testing.yaml` instead of expanding
  them directly inside `run:` blocks.
- **`undocumented-permissions`** — move the explanatory text onto the
  **same line** as each elevated permission (where zizmor looks for it)
  in `clear-action-cache.yaml`, `openssf-scorecard.yaml`,
  `release-drafter.yaml` and `tag-push.yaml`.
- **`concurrency-limits`** — add a workflow-level `concurrency` group
  to `tag-push.yaml` that serialises tag runs without cancelling an
  in-flight release promotion.

## Notes on the prior code-scanning alerts

The original `action.yaml` alerts (dangerous use of environment file /
code injection via template expansion) are resolved by the delimiter
rework above. The historical `autolabeler.yaml` alert was a stale SARIF
upload from a since-removed workflow (the scan configuration has since
changed); it has been dismissed from the portal separately.

## Validation

- `zizmor --persona=auditor` (online) → No findings
- `pre-commit` (yamllint, actionlint, reuse, gitlint, …) → all hooks pass