### PR TITLE
CI(security): Use harden-runner block mode

### DIFF
--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -49,11 +49,22 @@ jobs:
       # Actions cache deletion requires the actions: write scope.
       actions: write
     steps:
-      # Harden the runner
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Inspect cache before deletion'
         id: before

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -25,11 +25,22 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -25,11 +25,22 @@ jobs:
     outputs:
       tag: "${{ steps.tag_validate.outputs.tag_name }}"
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -56,11 +67,22 @@ jobs:
       contents: write
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -28,11 +28,22 @@ jobs:
       contents: read
     timeout-minutes: 10 # Increase this timeout value as needed
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

Switches the canonical template workflows from harden-runner **audit**
mode to **block** mode. Each job now runs the
[`harden-runner-block-action`][block] wrapper as a pre-step, which loads
the central egress allow-list from the organisation's `.github`
repository and publishes it as `$CONNECTION_ALLOW_LIST`. The subsequent
`step-security/harden-runner` step then consumes that list with
`egress-policy: block`, so the runner denies any host the allow-list
omits.

This mirrors the canonical pattern already deployed in
[`lfreleng-actions/.github`][dotgithub] and is a prerequisite for
propagating these template workflows down to consumer repositories.

## Pattern applied

```yaml
# Load the egress allow-list out-of-band from the
# organisation's .github repository and publish it as
# $CONNECTION_ALLOW_LIST for the harden-runner step below.
- uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
  with:
    config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1

# Harden the runner with the just-loaded allow-list.
- name: 'Harden runner (block)'
  uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
  with:
    egress-policy: 'block'
    allowed-endpoints: >
      ${{ env.CONNECTION_ALLOW_LIST }}
```

The wrapper fetches the allow-list out-of-band via a SHA-pinned git
fetch (not from the PR tree), so block mode remains safe for
`pull_request` workflows triggered from forks. The `config: '@<sha>'`
short form resolves the host org from `github.repository_owner`, keeping
the template portable across organisations.

Both the wrapper (`v0.2.0`) and the allow-list source (`v0.1.1`) are
pinned to immutable commit SHAs.

## Workflows updated

- `tag-push.yaml` (both `validate_tag` and `promote_release` jobs)
- `release-drafter.yaml`
- `testing.yaml`
- `clear-action-cache.yaml`

`openssf-scorecard.yaml` calls a reusable workflow and has no runner
step to harden, so it is unchanged.

## Validation

- `yamllint` — clean
- `actionlint` — clean
- Full `pre-commit` (incl. `gitlint`, `reuse`, workflow validators) — all
  hooks pass

[block]: https://github.com/lfreleng-actions/harden-runner-block-action
[dotgithub]: https://github.com/lfreleng-actions/.github
