### PR TITLE
Chore: refresh boilerplate workflow action pins

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ indent_size = 4
 [*.{json,yaml,yml}]
 indent_size = 2
 
-[*.markdown]
+[*.{md,markdown}]
 max_line_length = 80
 
 [*.py]

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -28,7 +28,7 @@ jobs:
   openssf-scorecard:
     name: "OpenSSF Scorecard"
     # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@f412e6f89527da7611a5f4a5f861de86d98d3e9e  # v0.7.0
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267  # v0.7.2
     permissions:
       contents: read  # Read repository contents (checkout, etc.)
       # yamllint disable-line rule:line-length

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -42,4 +42,4 @@ jobs:
             ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1


### PR DESCRIPTION
## Summary

Refreshes two stale action pins in the canonical boilerplate workflows
so `actions-template` stays current as the organisation's canonical
source. Both are the latest upstream releases and match what Dependabot
has already rolled out across much of the fleet.

| Action | From | To |
| ------ | ---- | -- |
| `release-drafter/release-drafter` | v7.4.0 | v7.5.1 |
| `lfit/releng-reusable-workflows` reuse-openssf-scorecard | v0.7.0 | v0.7.2 |

## Why

The fleet-wide zizmor remediation copies these boilerplate files
verbatim into consumer repositories. Several consumers already carry
the newer pins (via Dependabot); refreshing the template first ensures
those copies do not regress a newer pin.


## Also: editorconfig markdown glob fix

A second commit widens the `.editorconfig` section `[*.markdown]` to
`[*.{md,markdown}]`. The old glob never matched `.md` files (including
`README.md`), so `max_line_length = 80` never applied to markdown
content.

Copilot review of
[aislop-scan-action#1](https://github.com/lfreleng-actions/aislop-scan-action/pull/1)
flagged this in files inherited from this template;
[zizmor-scan-action#30](https://github.com/lfreleng-actions/zizmor-scan-action/pull/30)
carries the same fix for that repository. Since this repository is the
template the fleet generates action repos from, fixing it here stops
the issue propagating into new repositories.
