### PR TITLE
Feat: Add aislop quality gate to pre-commit

### DIFF
--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# aislop quality gate configuration.
+#
+# The default pass threshold is 75; repositories generated from this
+# template start clean, so hold the bar at 100 and fail the gate on
+# any regression. The pre-commit hook applies this gate. A template
+# consumer carrying legitimate exceptions can lower the threshold in
+# its own copy of this file.
+ci:
+  failBelow: 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,10 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ci:
-  # pre-commit.ci sandbox prevents network calls; disable gha-workflow-linter
-  skip: [gha-workflow-linter]
+  # pre-commit.ci sandbox prevents network calls; disable gha-workflow-linter.
+  # aislop also runs engines that can call the network at scan time
+  # (dependency audits), so it cannot run in the sandbox either.
+  skip: [gha-workflow-linter, aislop]
   autofix_commit_msg: |
     Chore: pre-commit autofixes
 
@@ -110,6 +112,23 @@ repos:
     rev: 4c3079dcb6e9e3c295f961ce5bd5b8585db698ca  # frozen: v1.2.2
     hooks:
       - id: gha-workflow-linter
+
+  # Catch AI slop developer-side before it reaches a pull request.
+  # Runs the full-repository quality gate, scored against
+  # .aislop/config.yml (failBelow: 100). A local hook installing the
+  # published npm package: the scanaislop/aislop git repository does
+  # not ship the built dist/, so its bundled pre-commit hook cannot
+  # install. Bump the pinned version here manually when new aislop
+  # releases ship.
+  - repo: local
+    hooks:
+      - id: aislop
+        name: aislop
+        entry: aislop ci --human
+        language: node
+        additional_dependencies: ["aislop@0.13.1"]
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 1a4bb160cab6417b3045e1b37b6b72449243e658  # frozen: 0.37.4


### PR DESCRIPTION
Add the [aislop](https://github.com/scanaislop/aislop) AI-slop / code-quality scanner to the pre-commit hooks, dogfooding the linting setup being introduced in [aislop-scan-action#1](https://github.com/lfreleng-actions/aislop-scan-action/pull/1) per review feedback there. Since this repository is the template new action repos generate from, the gate seeds into every new repository ahead of a bulk roll-out to existing consumers.

## What

- **`.pre-commit-config.yaml`**: an `aislop` hook running the **full-repository** quality gate (`aislop ci --human`, `always_run`, `pass_filenames: false`), catching slop developer-side before a PR wastes CI minutes. Also added to the pre-commit.ci `skip` list alongside `gha-workflow-linter` (aislop engines can call the network for dependency audits, which the pre-commit.ci sandbox blocks).
- **`.aislop/config.yml`**: `ci.failBelow: 100` — template-generated repositories start clean, so the bar is a perfect score; consumers with legitimate exceptions can lower it in their own copy.

## Implementation note

The hook is `repo: local` with `additional_dependencies: ["aislop@0.13.1"]` rather than sourcing `scanaislop/aislop` directly: the upstream git repository ships no built `dist/` and no `prepare` script, so its bundled pre-commit hook fails with `Executable aislop not found` (verified against the v0.13.1 tag). The local hook installs the published npm package instead — the same distribution channel `aislop-scan-action` pins.

## Validation

- `prek run --all-files` passes, including the new `aislop` hook.
- This repository holds no aislop-scoreable files (YAML/markdown boilerplate only), so the gate reports "not scored" and passes; enforcement engages in generated repositories as soon as they carry supported code.
- Gate enforcement verified in the sibling aislop-scan-action branch: a deliberately sloppy file drops the score to 74 and fails the hook.
