### PR TITLE
CI: Gate tag-push releases on tag validity checks

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: 'Verify pushed tag'
         id: tag_validate
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/tag-validate-action@bc8043ec074495cc8cdf351623ebab3675d563cf  # v1.0.4
+        uses: lfreleng-actions/tag-validate-action@aeca49ae6d1e87184477d803d30c4fa68777d814  # v1.1.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           require_type: 'semver'
@@ -65,6 +65,18 @@ jobs:
           require_github: 'true'
           # yamllint disable-line rule:line-length
           require_signed: 'ssh,gpg-unverifiable'  # Cannot verify GPG without key
+          # Block stale/lower-value tags (e.g. pushed from an
+          # out-of-sync fork) from triggering release promotion
+          enforce_increment: 'true'
+          # Tag commit must be reachable from the default branch
+          require_branch: "${{ github.event.repository.default_branch }}"
+          # Tag object must have been created within the last three
+          # minutes; blocks accidental pushes of old (test) tags that
+          # would otherwise create faulty immutable releases
+          require_recent: 'true'
+          # Tag must point at the current tip of the default branch;
+          # blocks releases built from outdated commit SHAs
+          require_latest: 'true'
 
   promote_release:
     name: 'Promote Draft Release'


### PR DESCRIPTION
## Summary

Enables the `tag-validate-action` release-gating inputs in the canonical
`tag-push.yaml` workflow, so repositories receiving this workflow reject
tags that would otherwise create a faulty release. With **immutable
releases** enabled across the org, a faulty release can only be deleted
(the tag cannot be re-pushed), leaving permanent gaps in release numbering.

Four gates are enabled:

- `enforce_increment: 'true'` — the pushed tag must be strictly greater
  than the highest existing tag in the repository
- `require_branch: "${{ github.event.repository.default_branch }}"` — the
  tag commit must be reachable from the default branch
- `require_recent: 'true'` — the tag object must have been created within
  the last three minutes (blocks accidental pushes of old test tags)
- `require_latest: 'true'` — the tag must point at the current tip of the
  default branch (blocks releases built from outdated commit SHAs)

The last two directly address the incident that motivated this work: a
~7-month-old test tag pushed to a fork produced a faulty immutable release.

## Dependency

Depends on: lfreleng-actions/tag-validate-action#253 (merged) and
lfreleng-actions/tag-validate-action#244 (merged), shipped in
**tag-validate-action v1.1.0**.

The action pin has been bumped from the current `main` baseline of **v1.0.4**
(`bc8043e...`) to the **v1.1.0 release commit SHA**
(`aeca49ae6d1e87184477d803d30c4fa68777d814`). The blocking `TODO` is removed
and this PR is ready for review.