### PR TITLE
Fix: Verify deleted cache IDs, not match count

### DIFF
--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -305,6 +305,9 @@ jobs:
             echo "| Total entries | $after_count |"
             echo "| Remaining matches | $remaining_matches |"
             echo ""
+            echo "Remaining matches counts every entry matching the"
+            echo "filters, including any created after this run began."
+            echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$DRY_RUN" = "true" ]; then
@@ -312,9 +315,60 @@ jobs:
             exit 0
           fi
 
-          if [ "$remaining_matches" -ne 0 ]; then
-            echo "::error::Expected zero matching cache entries " \
-              "after deletion, found $remaining_matches"
+          # Deletion targets the entries matched in the snapshot taken
+          # before it ran. Other workflows can save caches while this one
+          # is working, and a new entry may match the same filters, so a
+          # remaining-match count of zero is not a safe success
+          # condition: it turns an unrelated concurrent cache into a
+          # spurious failure. Assert instead that each entry actually
+          # targeted has gone, which is the guarantee this job owes its
+          # caller. The count above stays in the summary as information.
+          surviving_ids=''
+          if [ -s matched_ids.txt ] && [ -n "$all_caches" ]; then
+            # A blank line becomes an empty grep pattern, which matches
+            # every remaining ID and would invent survivors, so drop
+            # them before using the file as a pattern list. grep exits 1
+            # if that leaves nothing, which is fine, but a higher status
+            # is a genuine failure (unreadable file, bad usage). A
+            # blanket `|| true` would swallow those and let this step
+            # report success without having verified anything.
+            status=0
+            grep -v '^[[:space:]]*$' matched_ids.txt \
+              > targeted_ids.txt || status=$?
+            if [ "$status" -gt 1 ]; then
+              echo "::error::Could not read matched cache IDs" \
+                "(grep exit $status)"
+              exit 1
+            fi
+            if [ -s targeted_ids.txt ]; then
+              # Intersect in a single pass. Testing each targeted ID
+              # separately would re-scan the remaining list, and spawn a
+              # process, once per entry. jq runs on its own so `set -e`
+              # catches its failures: piped straight into grep, a jq
+              # error would hide behind grep's rightmost exit 1.
+              remaining_ids=$(printf '%s\n' "$all_caches" | jq -r '.id')
+              status=0
+              surviving_ids=$(
+                printf '%s\n' "$remaining_ids" \
+                  | grep -Fxf targeted_ids.txt
+              ) || status=$?
+              if [ "$status" -gt 1 ]; then
+                echo "::error::Could not compare remaining cache IDs" \
+                  "(grep exit $status)"
+                exit 1
+              fi
+            fi
+          fi
+
+          if [ -n "$surviving_ids" ]; then
+            printf '%s\n' "$surviving_ids" | while IFS= read -r cache_id; do
+              echo "::error::Cache entry $cache_id still present"
+            done
+            survivors=$(
+              printf '%s\n' "$surviving_ids" | wc -l | tr -d '[:space:]'
+            )
+            echo "::error::$survivors targeted cache entr(y/ies)" \
+              "survived deletion"
             exit 1
           fi
 


### PR DESCRIPTION
# Fix: Verify deleted cache IDs, not match count

Found while reviewing a verbatim copy of this workflow in `lfreleng-actions/test-maven-project` (lfreleng-actions/test-maven-project#2). The issue is in the canonical template, so it is fixed here first.

## Problem

`clear-action-cache.yaml`'s post-deletion check re-queried every cache, re-applied the caller's filters, and failed unless the match count reached zero:

```bash
if [ "$remaining_matches" -ne 0 ]; then
  echo "::error::Expected zero matching cache entries after deletion, found $remaining_matches"
  exit 1
fi
```

That asserts something the job cannot guarantee. Other workflows save caches while this one runs, and a new entry may match the same filters. With an empty `key_pattern` — which targets **every** entry — *any* concurrent cache save matches.

The result is a job that deleted exactly what it was asked to delete and then reports failure: the least useful outcome for a manual housekeeping run, and a confusing one to debug.

## Fix

Assert that each entry actually targeted has gone. The matched IDs are already captured in `matched_ids.txt` before deletion, so the check just uses what the earlier step recorded — no new bookkeeping:

```bash
surviving_ids=''
if [ -s matched_ids.txt ] && [ -n "$all_caches" ]; then
  status=0
  grep -v '^[[:space:]]*$' matched_ids.txt \
    > targeted_ids.txt || status=$?
  if [ "$status" -gt 1 ]; then
    echo "::error::Could not read matched cache IDs" \
      "(grep exit $status)"
    exit 1
  fi
  if [ -s targeted_ids.txt ]; then
    remaining_ids=$(printf '%s\n' "$all_caches" | jq -r '.id')
    status=0
    surviving_ids=$(
      printf '%s\n' "$remaining_ids" \
        | grep -Fxf targeted_ids.txt
    ) || status=$?
    if [ "$status" -gt 1 ]; then
      echo "::error::Could not compare remaining cache IDs" \
        "(grep exit $status)"
      exit 1
    fi
  fi
fi
```

This is the guarantee the job owes its caller: what you asked me to delete is gone. It says nothing about caches created afterwards, because it cannot.

The remaining-match count stays in the job summary as information, now labelled to explain that it also counts entries created after the run began.

Three details in the above are load-bearing, and each would be easy to lose in a well-meaning simplification:

- **Blank lines are stripped before the file becomes a pattern list.** A blank line is an empty `grep` pattern, which matches every remaining ID — the check would report every surviving cache as a failed deletion.
- **Only `grep` exit 1 is tolerated.** Exit 1 means "no match", the success case here. Higher statuses mean a real failure, such as an unreadable file. A blanket `|| true` swallowed both, so the step could report success without having verified anything.
- **`jq` runs on its own rather than piping into `grep`.** Under `pipefail` the pipeline takes the status of the *rightmost* failing command. A failing `jq` emits nothing, so `grep` exits 1 and hides `jq`'s 5. Standing alone, `jq` failures now abort the step under `set -e`.

## Validation

The block was extracted verbatim from the workflow and driven through each path, so the simulation cannot drift from the shipped code:

| Scenario | Result |
| -------- | ------ |
| Targeted gone, unrelated new cache appeared | exit 0 (**old logic failed here**) |
| One targeted entry survived | exit 1, 1 survivor |
| Two targeted entries survived | exit 1, 2 survivors |
| Blank line in `matched_ids.txt` | exit 0, not "all survived" |
| `matched_ids.txt` entirely blank | exit 0 |
| No caches remain at all | exit 0 |
| Unreadable `matched_ids.txt` | exit 1, "grep exit 2" |
| Malformed cache JSON | exit 5 |
| ID `1` against remaining `100`, `11` | exit 0, no substring match |

- `prek run --all-files` — clean
- `shellcheck -S info` — clean on the step body
- `zizmor --persona=auditor` — zero findings

## Downstream

Repositories that already copied this workflow carry the same behaviour. The immediate consumer is `test-maven-project`, which will take the corrected version in its own PR; a wider template re-sync can pick the rest up in the usual way.
