### PR TITLE
Chore: Pin ruff rule selection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,10 +58,8 @@ repos:
     rev: cb8c523fd4835aba42af70f4cad5568db4df0b6c  # frozen: v0.16.0
     hooks:
       - id: ruff
-        files: ^(scripts|tests|custom_components)/.+\.py$
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-        files: ^(scripts|tests|custom_components)/.+\.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Ruff configuration for repositories created from this template.
+#
+# The `select` list is pinned deliberately.  Without it ruff applies its
+# *default* rule set, and that default is not stable across releases:
+#
+#     ruff 0.15.22 ->  59 rules across  2 categories (E, F)
+#     ruff 0.16.0  -> 413 rules across 38 categories
+#
+# A routine pre-commit autoupdate therefore changed which rules run and
+# broke fifteen repositories in this organisation simultaneously, on code
+# that had not been touched.
+#
+# Selecting these categories switches every other rule off.  That is the
+# point: adopting more becomes a deliberate, reviewed edit to this file
+# rather than a side effect of a version bump.
+#
+# `line-length` and `target-version` are intentionally left unset so that
+# ruff's own defaults -- and its inference from `requires-python` where a
+# `pyproject.toml` exists -- continue to apply unchanged.
+
+[lint]
+# The de facto standard across this organisation: present as a superset in
+# 13 of the 16 repositories that already pin their rules.
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+
+ignore = [
+  "E501", # line-too-long: the formatter owns line length
+  "B008", # function call in argument default: typer/click idiom
+]
+
+[lint.per-file-ignores]
+# Test suites legitimately break rules that matter in library code.
+# Listed even though some are not currently selected, so that widening
+# `select` later does not immediately flag every test module.
+#
+# PLR0917 in particular cannot be satisfied in tests that stack
+# `@patch` decorators: unittest.mock injects its mocks positionally, so a
+# keyword-only signature is impossible, not merely inconvenient.
+"tests/**/*.py" = ["S101", "ARG", "PLR0913", "PLR0917", "PLR2004"]


### PR DESCRIPTION
## Why

Repos created from this template inherit the ruff hook but **no ruff configuration**, so they run whatever ruff's *default* rule set happens to be. That default is not stable across releases — verified directly:

```
$ ruff 0.15.22 check --show-settings --isolated
 59 rules across  2 categories (E, F)

$ ruff 0.16.0 check --show-settings --isolated
413 rules across 38 categories
(+ I, UP, SIM, RUF, B, BLE, PIE, EXE, PLW, PLR, S, PTH, TRY, PYI, FURB, …)
```

A 7× expansion in a patch-level bump. The routine `pre-commit autoupdate` that crossed it **broke 15 repositories in this org simultaneously**, on code nobody had touched — 54 lint violations plus 71 lines of autofix, all on files that were 100% clean the day before.

This template is the origin of that exposure: **96 of the org's repos carry the ruff hook with no config**, so they are all lined up for the next bump.

## What

### 1. `.ruff.toml` pinning the rule set

```toml
[lint]
select = ["E", "W", "F", "I", "B", "C4", "UP"]
ignore = ["E501", "B008"]
```

Not invented — this is the **de facto house style**, present as a superset in **13 of the 16** org repos that already pin their rules. `E501`+`B008` are ignored in 14 and 13 of those 16 respectively.

A standalone `.ruff.toml` rather than `[tool.ruff]` because this template has no `pyproject.toml`, and a repo created from it should inherit working config whether or not it later becomes a packaged project.

**Selecting these categories switches every other rule off — that is the point.** Adopting `SIM`, `BLE`, `PIE` and friends becomes a deliberate, reviewed change rather than a side effect of a version bump.

### 2. `line-length` and `target-version` deliberately left unset

Both would change existing behaviour rather than just pinning it — `target-version` alters which `pyupgrade` rules fire, and `line-length` drives the formatter. Ruff's defaults (and its inference from `requires-python`) continue to apply unchanged. Standardising those is separate work.

### 3. The `files:` pattern dropped from both ruff hooks

The inherited pattern was:

```yaml
files: ^(scripts|tests|custom_components)/.+\.py$
```

Two defects:

- **It omits `src/`**, so any repo in a src layout has its entire package silently unlinted. This is not hypothetical — 9 repos are affected, including `project-reporting-tool` (81 files), `gerrit-clone-action` (33) and `dependamerge` (36). Three repos (`aislop-scan-action`, `sigul-sign-docker`, `zizmor-scan-action`) currently lint **nothing at all**.
- **`custom_components/` is a Home Assistant artifact** that exists in **zero** repos in this org, yet has propagated to 103 of them.

The smoking gun: several repos carry `per-file-ignores` for paths the hook can never reach — `gerrit-clone-action` has 7 entries for `src/gerrit_clone/*.py`. Someone wrote config for files ruff was never shown.

Removing `files:` restores the upstream hook default (`types_or: [python, pyi]`), i.e. lint all Python.

## Validation

- `ruff check --show-settings` confirms enabled categories drop from 38 to `B C E F I UP W`
- `pre-commit run --all-files` → all hooks pass, including `reuse lint` on the new file
- This repo contains no Python, so the `files:` change is inert here and only affects repos created from the template

## Scope

This is step 1 of a sequenced rollout. Steps 2–3 pin `select` in the 14 exposed repos that *do* contain Python and add `PLR0917` to the 3 that already select `PL`. Fixing `files:` in existing repos is deliberately **last**, since it surfaces previously-unlinted code and must land after `select` is pinned.
